### PR TITLE
DPTSO-5285 enable az zones test

### DIFF
--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -15,3 +15,5 @@ linux_node_pool = {
   min_nodes = 4,
   max_nodes = 10
 }
+
+availability_zones = ["2"]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-5285

### Change description ###

Enable Availability Zone test on SBOX environment, plan is to test with two AZ's, then return to one AZ being the default for this environment. Shared module being used here, we only need to add new availability zone variable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
