### PR TITLE
revert zones back to 1 for SBOX

### DIFF
--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -16,4 +16,4 @@ linux_node_pool = {
   max_nodes = 10
 }
 
-availability_zones = ["1", "2", "3"]
+availability_zones = ["1"]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-5285

### Change description ###

Revert availability zones back to 1 for the SBOX environment, previously tested with 2 and 3 AZs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
