### PR TITLE
aks downgrade version from 1.21.2 to 1.20.9

### DIFF
--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -1,5 +1,5 @@
 cluster_count                      = 2
-kubernetes_cluster_version         = "1.21.2"
+kubernetes_cluster_version         = "1.20.9"
 kubernetes_cluster_agent_min_count = "6"
 kubernetes_cluster_agent_max_count = "15"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCeRwSzSKJfjmIVQ6CUld/M3vF9Hcfxh5cLBa1BV+UZDh5p1gKoB0xRegSFdncfup1qMAhrZtgBpaclLiYUfe8ZajPp1Lmva9AJuK/UktzF9stZie7LDpflEdVBXlSZw3AtAWxF2vIkEeW+NVYlGAJOQlasFkmGTkco+O1wUM4LGI3YNHm7r70rnmHT2djoR1t4x1jlPCrXaJEhvtyxf01Dwjq2nWaox3puJtHs5DLFpEIvXvHwQWssFFyKIuwkm4FewHKJSbCahyaCb+ac10MAZg9vZnWq0EYOe1nLn7c3538yJ9WJh7jRFZDza6ab9HVb5hgJ3/t/K+EzkU/XGSEJ"


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-2200

### Change description ###

Downgrade AKS cluster on SBOX 00 and 01 from version 1.21.2 to 1.20.9.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
