### PR TITLE
remove depends_on uami_cft_rg_identity_operator role assignment

### DIFF
--- a/components/aks/cft_aks.tf
+++ b/components/aks/cft_aks.tf
@@ -9,8 +9,6 @@ resource "azurerm_role_assignment" "uami_cft_rg_identity_operator" {
   principal_id         = module.kubernetes["${count.index}"].kubelet_object_id
   scope                = data.azurerm_resource_group.managed-identity-operator-cft-mi.id
   role_definition_name = "Managed Identity Operator"
-
-  depends_on = [module.kubernetes]
 }
 
 # data "azurerm_resource_group" "managed-identity-operator-cft" {


### PR DESCRIPTION
### Change description ###
Causing issues when attempting terraform destroy
- Tested locally and seemed ok for TF to understand
- hopefully it doesn't fail during a TF apply :)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
