### PR TITLE
replaced old cftptl vnet woute for appgw with new ptl vnet network space

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -66,8 +66,8 @@ additional_routes_appgw = [
     next_hop_in_ip_address = "10.11.8.36"
   },
   {
-    name                   = "core_cftptl_intvsc_vnet"
-    address_prefix         = "10.10.64.0/21"
+    name                   = "cft-ptl-vnet"
+    address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
   },

--- a/environments/network/ithc.tfvars
+++ b/environments/network/ithc.tfvars
@@ -57,8 +57,8 @@ additional_routes_appgw = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
-    name                   = "core_cftptl_intvsc_vnet"
-    address_prefix         = "10.10.64.0/21"
+    name                   = "cft-ptl-vnet"
+    address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   }

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -57,8 +57,8 @@ additional_routes_appgw = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
-    name                   = "core_cftptl_intvsc_vnet"
-    address_prefix         = "10.10.64.0/21"
+    name                   = "cft-ptl-vnet"
+    address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   }

--- a/environments/network/preview.tfvars
+++ b/environments/network/preview.tfvars
@@ -61,8 +61,8 @@ additional_routes_appgw = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
-    name                   = "core_cftptl_intvsc_vnet"
-    address_prefix         = "10.10.64.0/21"
+    name                   = "cft-ptl-vnet"
+    address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Following on from PTL cluster switchover there were some jobs failing to connect to aat. I realised that within the network tfvars the appgw had a route configured for the old cftptl cluster. Updating this manually to the new network address space for the new PTL cluster fixed the issue. This change is to permanently add this change to all envs with reference to cftptl to allow Jenkins to connect to them.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
