### PR TITLE
DTSPO-6657 - Preview AKS version upgrade to 1.21.7

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -67,7 +67,7 @@ module "kubernetes" {
 
   enable_user_system_nodepool_split = var.enable_user_system_nodepool_split == true ? true : false
 
-  additional_node_pools = contains(["ptl", "aat", "preview", "demo", "prod"], var.environment) ? [] : [
+  additional_node_pools = contains(["ptl", "aat", "demo", "prod"], var.environment) ? [] : [
     {
       name                = "linux"
       vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -1,5 +1,5 @@
 cluster_count                      = 2
-kubernetes_cluster_version         = "1.19.11"
+kubernetes_cluster_version         = "1.21.7"
 kubernetes_cluster_agent_min_count = "30"
 kubernetes_cluster_agent_max_count = "100"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6657


### Change description ###
Upgrade AKS version to 1.21.7 and enable nodepool


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
