### PR TITLE
DTSPO-6658 - AAT - AKS Upgrade to v1.21.7

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -67,7 +67,7 @@ module "kubernetes" {
 
   enable_user_system_nodepool_split = var.enable_user_system_nodepool_split == true ? true : false
 
-  additional_node_pools = contains(["ptl", "aat", "demo", "prod"], var.environment) ? [] : [
+  additional_node_pools = contains(["ptl", "demo", "prod"], var.environment) ? [] : [
     {
       name                = "linux"
       vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")

--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -4,6 +4,7 @@ kubernetes_cluster_agent_min_count = "40"
 kubernetes_cluster_agent_max_count = "60"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfTT+Bu3rkDptVCj03j8jyflM6bZxNp4tgi0GibRciAops5dOkbtoWKBNpHfGH5AlTKnReRJTlfqM88DjGnYZwYtfx7Kqf3rxNXfwFqXrVYETGy0SNo11WrBSNHDnyfNVm5UFE7HmpSoGVr+C9/OCVmzTDbYoPppGZ79Iv74CLMpsIM8XuD2lQAolODLfA55OTdeJJLgyFu0cEB3ZrrM2DXwMm5CI8C05ACDvDkEO4vtGK9OCYYkxT9/3pskk/ub+IpjuEajryK2fhsPDFwmTVzaMAvM9HIIvDyvfJXjGlGp12d/wubHQ3HlXgUxvU2UF+ggPaaSfQnqALtQ/PwcHf aks-ssh"
 sku_tier                           = "Paid"
+enable_user_system_nodepool_split  = true
 
 system_node_pool = {
   min_nodes = 40,

--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -1,5 +1,5 @@
 cluster_count                      = 2
-kubernetes_cluster_version         = "1.19.11"
+kubernetes_cluster_version         = "1.21.7"
 kubernetes_cluster_agent_min_count = "40"
 kubernetes_cluster_agent_max_count = "60"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfTT+Bu3rkDptVCj03j8jyflM6bZxNp4tgi0GibRciAops5dOkbtoWKBNpHfGH5AlTKnReRJTlfqM88DjGnYZwYtfx7Kqf3rxNXfwFqXrVYETGy0SNo11WrBSNHDnyfNVm5UFE7HmpSoGVr+C9/OCVmzTDbYoPppGZ79Iv74CLMpsIM8XuD2lQAolODLfA55OTdeJJLgyFu0cEB3ZrrM2DXwMm5CI8C05ACDvDkEO4vtGK9OCYYkxT9/3pskk/ub+IpjuEajryK2fhsPDFwmTVzaMAvM9HIIvDyvfJXjGlGp12d/wubHQ3HlXgUxvU2UF+ggPaaSfQnqALtQ/PwcHf aks-ssh"
@@ -14,4 +14,4 @@ linux_node_pool = {
   max_nodes = 10
 }
 
-availability_zones = []
+availability_zones = ["1", "2", "3"]


### PR DESCRIPTION
### JIRA link (if applicable) ###
Upgrade AAT AKS version to 1.21.7 and enable nodepool


### Change description ###
https://tools.hmcts.net/jira/browse/DTSPO-6658


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
