### PR TITLE
Dtspo 6653 aks upgrade ptl jenkins cluster

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -67,7 +67,7 @@ module "kubernetes" {
 
   enable_user_system_nodepool_split = var.enable_user_system_nodepool_split == true ? true : false
 
-  additional_node_pools = contains(["ptl", "demo", "prod"], var.environment) ? [] : [
+  additional_node_pools = contains(["demo", "prod"], var.environment) ? [] : [
     {
       name                = "linux"
       vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -18,4 +18,4 @@ linux_node_pool = {
   max_nodes = 10
 }
 
-availability_zones = []
+availability_zones = ["1", "2", "3"]

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -1,20 +1,20 @@
 cluster_count                      = 1
-kubernetes_cluster_version         = "1.19.11"
+kubernetes_cluster_version         = "1.21.7"
 kubernetes_cluster_agent_min_count = "8"
 kubernetes_cluster_agent_max_count = "10"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"
 ptl_cluster                        = true
-enable_user_system_nodepool_split  = false
+enable_user_system_nodepool_split  = true
 
 kubernetes_cluster_agent_vm_size = "Standard_DS4_v2"
 
 system_node_pool = {
   vm_size   = "Standard_DS4_v2",
-  min_nodes = 8,
-  max_nodes = 10
+  min_nodes = 2,
+  max_nodes = 4
 }
 linux_node_pool = {
-  min_nodes = 4,
+  min_nodes = 8,
   max_nodes = 10
 }
 

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -18,4 +18,4 @@ linux_node_pool = {
   max_nodes = 10
 }
 
-availability_zones = ["1", "2", "3"]
+availability_zones = ["1"]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-6653

### Change description ###

AKS upgrade to version 1.21.7 and enable split node pools. No availability zone required for this activity.
CHG5007183 - raised to carryout this work 28th Feb starting 19:00-00:00.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
