### PR TITLE
DTSPO-7038 - AAT - Disable AKS multi Availability Zones

### DIFF
--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -14,4 +14,4 @@ linux_node_pool = {
   max_nodes = 60
 }
 
-availability_zones = ["1", "2", "3"]
+availability_zones = ["1"]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7038


### Change description ###
Disabling multi AZ in AAT - Not supported by cluster autoscaler.

![image](https://user-images.githubusercontent.com/22701260/155359338-4a8527af-7bb8-448a-ab41-fc973052de12.png)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
