### PR TITLE
add test.platform.hmcts.net to demo

### DIFF
--- a/environments/network/demo.tfvars
+++ b/environments/network/demo.tfvars
@@ -17,7 +17,8 @@ private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 private_dns_zones = [
   "demo.platform.hmcts.net",
   "service.core-compute-demo.internal",
-  "service.core-compute-idam-demo.internal"
+  "service.core-compute-idam-demo.internal",
+  "test.platform.hmcts.net"
 ]
 
 hub = "nonprod"


### PR DESCRIPTION
### Change description ###
add test.platform.hmcts.net to demo
- required for apim to communicate to  test.platform.hmcts.net  private dns

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
