### PR TITLE
DTSPO-7029 - upgrade terraform and azurerm provider

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ parameters:
 
 variables:
   - name: tfversion
-    value: 1.0.10
+    value: 1.1.7
   - name: project
     value: cft
   - name: serviceConnection

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -23,7 +23,7 @@ module "loganalytics" {
 
 module "kubernetes" {
   count  = var.cluster_count
-  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
+  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=DTSPO-7029-upgrade-azurerm-provider"
 
   control_resource_group = "azure-control-${local.control_resource_environment}-rg"
   environment            = var.environment

--- a/components/aks/init.tf
+++ b/components/aks/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.10"
+  required_version = ">= 1.1.7"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "2.77.0"
+      version               = "3.0.2"
       configuration_aliases = [azurerm.hmcts-control]
     }
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7029


### Change description ###
Upgrading terraform version and azurerm provider to the latest versions, this is in preparation of DTSPO-7029. These changes have been tested on the sds clusters with only a role assignment needing to be recreated.

[Example SDS Run](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=220256&view=logs&j=9529ead6-39ae-5319-1740-9d2035106bd6&t=89b2e481-5d95-5be1-d64b-e101e3d88784)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
