### PR TITLE
Update AAT to cft-aks-aat-vnet rather than subnets

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -110,14 +110,8 @@ additional_routes_appgw = [
 
 additional_routes_coreinfra = [
   {
-    name                   = "aks-00"
-    address_prefix         = "10.10.128.0/20"
-    next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.8.36"
-  },
-  {
-    name                   = "aks-01"
-    address_prefix         = "10.10.144.0/20"
+    name                   = "cft-aks-aat-vnet"
+    address_prefix         = "10.10.128.0/18"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
   },


### PR DESCRIPTION
### Change description ###
Update AAT to cft-aks-aat-vnet rather than subnets
- will fix core-apim-aat connectivity. Currently there is timeouts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
