### PR TITLE
np: use VERSION env var

### DIFF
--- a/bootstrap/scripts/install-sealed-secrets.sh
+++ b/bootstrap/scripts/install-sealed-secrets.sh
@@ -2,7 +2,7 @@
 set -e
 
 VAULT_NAME=${8}
-VERSION="1.10.3"
+VERSION="2.1.6"
 NAMESPACE="admin"
 
 if [ ! -f sealed-secrets-pki.yaml ]; then
@@ -16,5 +16,5 @@ fi
 kubectl apply -f sealed-secrets-pki.yaml
 
 helm repo add bitnami-labs https://bitnami-labs.github.io/sealed-secrets/
-helm upgrade sealed-secrets bitnami-labs/sealed-secrets --version 2.1.6 --install --namespace ${NAMESPACE} \
+helm upgrade sealed-secrets bitnami-labs/sealed-secrets --version ${VERSION} --install --namespace ${NAMESPACE} \
      -f  deployments/sealed-secrets/values.yaml --set secretName=sealed-secrets-pki --wait \


### PR DESCRIPTION
### JIRA link N/A ###

### Change description ###
VERSION env var was not being used and had an old version set which can cause confusion when looking for the current sealed secret version used. Updated the variable and use it where it was being applied inline.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
