### PR TITLE
breaking change for azcli 2.37

### DIFF
--- a/bootstrap/scripts/create-cluster-admins.sh
+++ b/bootstrap/scripts/create-cluster-admins.sh
@@ -6,9 +6,9 @@ AAD_ADMIN_GROUP_NAME=(dcd_group_aks_admin_global_v2)
 CLUSTER_ADMINS_GROUP_PREFIX=(dcd_group_aks_admin_)
 
 SUBSCRIPTION_NAME=$(az account show --query name --verbose -o tsv)
-CLUSTER_GLOBAL_ADMINS_GROUP=$(az ad group list --query "[?displayName=='${AAD_ADMIN_GROUP_NAME}'].objectId" --verbose -o tsv)
+CLUSTER_GLOBAL_ADMINS_GROUP=$(az ad group list --query "[?displayName=='${AAD_ADMIN_GROUP_NAME}'].id" --verbose -o tsv)
 CLUSTER_ADMINS_GROUP_NAME="${CLUSTER_ADMINS_GROUP_PREFIX}${SUBSCRIPTION_NAME,,}_v2"
-CLUSTER_ADMIN_GROUP=$(az ad group list --query "[?displayName=='${CLUSTER_ADMINS_GROUP_NAME}'].objectId" --verbose -o tsv)
+CLUSTER_ADMIN_GROUP=$(az ad group list --query "[?displayName=='${CLUSTER_ADMINS_GROUP_NAME}'].id" --verbose -o tsv)
 
 if [ -z "${CLUSTER_ADMIN_GROUP}" ]; then
     echo "Cluster admin group doesn't exist, aborting"


### PR DESCRIPTION
### Change description ###
breaking change for azcli 2.37
- For example, the most outstanding change is that the objectId property in the output JSON of a Graph object is replaced by id.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
