### PR TITLE
DTSPO-8615 added routing rules for core-infra vnet to soc_prod 

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -149,7 +149,7 @@ additional_routes_coreinfra = [
     name                   = "soc_prod"
     address_prefix         = "10.146.0.0/21"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.36"
+    next_hop_in_ip_address = "10.11.8.36"
   }
 ]
 

--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -144,6 +144,12 @@ additional_routes_coreinfra = [
     address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "soc_prod"
+    address_prefix         = "10.146.0.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/ithc.tfvars
+++ b/environments/network/ithc.tfvars
@@ -87,6 +87,12 @@ additional_routes_coreinfra = [
     address_prefix         = "10.11.208.0/20"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "soc_prod"
+    address_prefix         = "10.146.0.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -92,7 +92,7 @@ additional_routes_coreinfra = [
     name                   = "soc_prod"
     address_prefix         = "10.146.0.0/21"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "0.11.72.36"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -87,6 +87,12 @@ additional_routes_coreinfra = [
     address_prefix         = "10.48.80.0/20"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "soc_prod"
+    address_prefix         = "10.146.0.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "0.11.72.36"
   }
 ]
 

--- a/environments/network/prod.tfvars
+++ b/environments/network/prod.tfvars
@@ -87,6 +87,12 @@ additional_routes_coreinfra = [
     address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "soc_prod"
+    address_prefix         = "10.146.0.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
   }
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-8615
https://tools.hmcts.net/jira/browse/DTSPO-8616

### Change description ###

Splunk UF forwarder needs to send traffic to the Splunk Server, it is routeed through the non-prod palo alto to the splunk server. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
