### PR TITLE
DTSPO-9049 - Update ptl state backend

### DIFF
--- a/components/aks/init.tf
+++ b/components/aks/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "3.13.0"
+      version               = "3.14.0"
       configuration_aliases = [azurerm.hmcts-control]
     }
   }

--- a/pipeline-steps/deploy-network.yaml
+++ b/pipeline-steps/deploy-network.yaml
@@ -38,9 +38,7 @@ steps:
          backendAzureRmResourceGroupName: 'azure-control-stg-rg'
       ${{ if eq( parameters['environment'], 'ptlsbox') }}: 
          backendAzureRmResourceGroupName: 'azure-control-sbox-rg'
-      ${{ if eq( parameters['environment'], 'ptl') }}: 
-         backendAzureRmResourceGroupName: 'azure-control-prod-rg'
-      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'ptl', 'preview') }}: 
+      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'preview') }}: 
          backendAzureRmResourceGroupName: 'azure-control-${{ parameters.environment }}-rg'
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
       backendAzureRmStorageAccountName: $(controlStorageAccount)

--- a/pipeline-steps/deploy-service.yaml
+++ b/pipeline-steps/deploy-service.yaml
@@ -38,9 +38,7 @@ steps:
          backendAzureRmResourceGroupName: 'azure-control-stg-rg'
       ${{ if eq( parameters['environment'], 'ptlsbox') }}: 
          backendAzureRmResourceGroupName: 'azure-control-sbox-rg'
-      ${{ if eq( parameters['environment'], 'ptl') }}: 
-         backendAzureRmResourceGroupName: 'azure-control-prod-rg'
-      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'ptl', 'preview') }}: 
+      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'preview') }}: 
          backendAzureRmResourceGroupName: 'azure-control-${{ parameters.environment }}-rg'
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
       backendAzureRmStorageAccountName: $(controlStorageAccount)

--- a/pipeline-steps/destroy-service.yaml
+++ b/pipeline-steps/destroy-service.yaml
@@ -52,9 +52,7 @@ steps:
             backendAzureRmResourceGroupName: 'azure-control-stg-rg'
           ${{ if eq( parameters['environment'], 'ptlsbox') }}:
             backendAzureRmResourceGroupName: 'azure-control-sbox-rg'
-          ${{ if eq( parameters['environment'], 'ptl') }}:
-            backendAzureRmResourceGroupName: 'azure-control-prod-rg'
-          ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'ptl', 'preview') }}:
+          ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'preview') }}:
             backendAzureRmResourceGroupName: 'azure-control-${{ parameters.environment }}-rg'
           backendAzureRmResourceGroupLocation: ${{ parameters.location }}
           backendAzureRmStorageAccountName: $(controlStorageAccount)

--- a/pipeline-steps/genesis.yaml
+++ b/pipeline-steps/genesis.yaml
@@ -39,9 +39,7 @@ steps:
          backendAzureRmResourceGroupName: 'azure-control-stg-rg'
       ${{ if eq( parameters['environment'], 'ptlsbox') }}: 
          backendAzureRmResourceGroupName: 'azure-control-sbox-rg'
-      ${{ if eq( parameters['environment'], 'ptl') }}: 
-         backendAzureRmResourceGroupName: 'azure-control-prod-rg'
-      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'ptl', 'preview') }}: 
+      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'preview') }}: 
          backendAzureRmResourceGroupName: 'azure-control-${{ parameters.environment }}-rg'
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
       backendAzureRmStorageAccountName: $(controlStorageAccount)

--- a/pipeline-steps/managed_identity.yaml
+++ b/pipeline-steps/managed_identity.yaml
@@ -37,9 +37,7 @@ steps:
          backendAzureRmResourceGroupName: 'azure-control-stg-rg'
       ${{ if eq( parameters['environment'], 'ptlsbox') }}: 
          backendAzureRmResourceGroupName: 'azure-control-sbox-rg'
-      ${{ if eq( parameters['environment'], 'ptl') }}: 
-         backendAzureRmResourceGroupName: 'azure-control-prod-rg'
-      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'ptl', 'preview') }}: 
+      ${{ if notIn( parameters['environment'], 'aat', 'perftest', 'ptlsbox', 'preview') }}: 
          backendAzureRmResourceGroupName: 'azure-control-${{ parameters.environment }}-rg'
       backendAzureRmResourceGroupLocation: ${{ parameters.location }}
       backendAzureRmStorageAccountName: $(controlStorageAccount)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9049


### Change description ###
Remove condition that looks for ptl remote state in prod resource group
AzureRM provider version for AKS module also needs to be updated as a result of 3.14 being used in https://github.com/hmcts/aks-module-kubernetes/tree/renovate/azurerm-3.x which is being referenced [here](https://github.com/hmcts/aks-cft-deploy/blob/791e8e1a804e06255cc3e31917e4250c8bba50a1/components/aks/aks.tf#L26)
Renovate PR exists for updating provider in other components https://github.com/hmcts/aks-cft-deploy/pull/225


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
