### PR TITLE
create upgraded cluster to test preview AKS version 1.23

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ parameters:
   - name: cluster
     displayName: Cluster
     type: string
-    default: 'All'
+    default: '00'
     values:
     - 'All'
     - '00'
@@ -36,7 +36,7 @@ parameters:
   - name: env
     displayName: Environment
     type: string
-    default: 'SBOX'
+    default: 'PREVIEW'
     values:
     - ITHC
     - PREVIEW

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ parameters:
   - name: cluster
     displayName: Cluster
     type: string
-    default: '00'
+    default: 'All'
     values:
     - 'All'
     - '00'
@@ -36,7 +36,7 @@ parameters:
   - name: env
     displayName: Environment
     type: string
-    default: 'PREVIEW'
+    default: 'SBOX'
     values:
     - ITHC
     - PREVIEW

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -1,5 +1,5 @@
 cluster_count                      = 2
-kubernetes_cluster_version         = "1.21.7"
+kubernetes_cluster_version         = "1.23"
 kubernetes_cluster_agent_min_count = "30"
 kubernetes_cluster_agent_max_count = "140"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

### JIRA link [DTSPO-8328](https://tools.hmcts.net/jira/browse/DTSPO-8328)###

### Change description ###

It's already End of life for AKS 1.21 so we need to create a Preview cluster with k8s 1.23. We will need to update APIs in place then and afterwards we can do the cluster swap.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No (I will trigger the pipeline on preview 00 (the cluster is currently not accessible and won't impact developers)
```
