### PR TITLE
add staging.platform.hmcts.net zone to aat

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -26,6 +26,7 @@ private_dns_zones = [
   "service.core-compute-idam-aat2.internal",
   "service.core-compute-preview.internal",
   "service.core-compute-idam-preview.internal",
+  "staging.platform.hmcts.net"
 ]
 
 hub = "prod"


### PR DESCRIPTION
### Change description ###
add staging.platform.hmcts.net zone to aat
- aat required to access https://hmi-apim.staging.platform.hmcts.net/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
