### PR TITLE
updated locals to ensure that PTL env points to the ptl control

### DIFF
--- a/components/managed-identity/interpolated-defaults.tf
+++ b/components/managed-identity/interpolated-defaults.tf
@@ -10,7 +10,7 @@ data "azurerm_resource_group" "genesis_rg" {
 
 locals {
 
-  environment = (var.environment == "perftest") ? "test" : (var.environment == "aat") ? "stg" : (var.environment == "ptlsbox") ? "sbox" : (var.environment == "preview") ? "dev" : (var.environment == "ptl") ? "prod" : "${var.environment}"
+  environment = (var.environment == "perftest") ? "test" : (var.environment == "aat") ? "stg" : (var.environment == "ptlsbox") ? "sbox" : (var.environment == "preview") ? "dev" : (var.environment == "ptl") ? "ptl" : "${var.environment}"
 
 }
 


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

Updated locals so that PTL env points to the correct control resource group for the KV it uses. 

Looks as though the KV may have moved to a different RG than what it was in previously.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
