### PR TITLE
Passthrough object id for AKS version checker

### DIFF
--- a/.github/workflows/run-updatecli.yaml
+++ b/.github/workflows/run-updatecli.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: mikefarah/yq@master
       - name: Run Updatecli in Dry Run mode
         run: |
-          yq '.environments' updatecli/values.github-action.yaml | cut -d "-" -f 2 | while read i
+          yq -r '.environments | to_entries | map(select(.value.enabled == true)) | .[].key' updatecli/values.github-action.yaml | while read i
           do
               CURRENT_ITER_ENVIRONMENT="$i" updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
           done
@@ -43,7 +43,7 @@ jobs:
       - name: Run Updatecli in Apply mode
         if: github.ref == 'refs/heads/main'
         run: |
-          yq '.environments' updatecli/values.github-action.yaml | cut -d "-" -f 2 | while read i
+          yq -r '.environments | to_entries | map(select(.value.enabled == true)) | .[].key' updatecli/values.github-action.yaml | while read i
           do
               CURRENT_ITER_ENVIRONMENT="$i" updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
           done

--- a/.github/workflows/run-updatecli.yaml
+++ b/.github/workflows/run-updatecli.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           client-id: b430ef1e-4e79-4e92-a152-8e5b5bc195d4 # DTS CFT AKS version checker
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
-          subscription-id: a8140a9e-f1b0-481f-a4de-09e2ee23f7ab # DTS-SHAREDSERVICES-SBOX
+          allow-no-subscriptions: true
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@v2
         with:

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -21,6 +21,10 @@ module "loganalytics" {
   environment = var.environment
 }
 
+data "azuread_service_principal" "version_checker" {
+  display_name = "DTS CFT AKS version checker"
+}
+
 module "kubernetes" {
   count  = var.cluster_count
   source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
@@ -89,6 +93,7 @@ module "kubernetes" {
   enable_automatic_channel_upgrade_patch = var.enable_automatic_channel_upgrade_patch
   workload_identity_enabled              = var.workload_identity_enabled
 
+  aks_version_checker_principal_id = data.azuread_service_principal.version_checker.object_id
 }
 
 module "ctags" {

--- a/updatecli/get-latest-aks-upgrade-version.sh
+++ b/updatecli/get-latest-aks-upgrade-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+aks_name=$1
+aks_resource_group=$2
+aks_subscription=$3
+
+az aks get-upgrades \
+    --name $aks_name \
+    --resource-group $aks_resource_group \
+    --subscription $aks_subscription \
+    | jq -r '
+    if (.controlPlaneProfile.upgrades == null) then
+        .controlPlaneProfile.kubernetesVersion
+    else .controlPlaneProfile.upgrades|map(select(.isPreview == null).kubernetesVersion)
+    | .[] end' \
+    | sort --reverse --version-sort | head --lines 1

--- a/updatecli/get-latest-ga-aks-version.sh
+++ b/updatecli/get-latest-ga-aks-version.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-az aks get-versions --location uksouth --query 'orchestrators[?isPreview==null].orchestratorVersion' -o tsv | sort -r --version-sort | head -n 1

--- a/updatecli/updatecli.d/aks-version.yaml
+++ b/updatecli/updatecli.d/aks-version.yaml
@@ -1,10 +1,10 @@
 ---
 version: 0.33.3
 name: "Update aks version"
-  {{ $environment := (requiredEnv "CURRENT_ITER_ENVIRONMENT") }}
-  {{ $aks_name := (index .environments $environment).aks_name }}
-  {{ $aks_resource_group := (index .environments $environment).aks_resource_group }}
-  {{ $aks_subscription := (index .environments $environment).aks_subscription }}
+{{ $environment := (requiredEnv "CURRENT_ITER_ENVIRONMENT") }}
+{{ $aks_name := (index .environments $environment).aks_name }}
+{{ $aks_resource_group := (index .environments $environment).aks_resource_group }}
+{{ $aks_subscription := (index .environments $environment).aks_subscription }}
 
 pipelineid: "updatecli_aks_version_{{ $environment }}"
 

--- a/updatecli/updatecli.d/aks-version.yaml
+++ b/updatecli/updatecli.d/aks-version.yaml
@@ -1,8 +1,10 @@
 ---
 version: 0.33.3
 name: "Update aks version"
-
-{{ $environment := (requiredEnv "CURRENT_ITER_ENVIRONMENT") }}
+  {{ $environment := (requiredEnv "CURRENT_ITER_ENVIRONMENT") }}
+  {{ $aks_name := (index .environments $environment).aks_name }}
+  {{ $aks_resource_group := (index .environments $environment).aks_resource_group }}
+  {{ $aks_subscription := (index .environments $environment).aks_subscription }}
 
 pipelineid: "updatecli_aks_version_{{ $environment }}"
 
@@ -23,7 +25,7 @@ sources:
     kind: shell
     name: Get latest AKS version for a given region
     spec:
-      command: ./updatecli/get-latest-ga-aks-version.sh
+      command: ./updatecli/get-latest-aks-upgrade-version.sh {{ $aks_name }} {{ $aks_resource_group }} {{ $aks_subscription }}
       versionfilter:
         kind: semver
     transformers:

--- a/updatecli/values.github-action.yaml
+++ b/updatecli/values.github-action.yaml
@@ -5,12 +5,48 @@ github:
   owner: "hmcts"
   repository: "aks-cft-deploy"
 environments:
-  - aat
-  - demo
-  - ithc
-  - perftest
-  - preview
-  - prod
-  - ptl
-  - ptlsbox
-  - sbox
+  sbox:
+    enabled: true
+    aks_name: cft-sbox-00-aks
+    aks_resource_group: cft-sbox-00-rg
+    aks_subscription: DCD-CFTAPPS-SBOX
+  demo:
+    enabled: true
+    aks_name: cft-demo-00-aks
+    aks_resource_group: cft-demo-00-rg
+    aks_subscription: DCD-CFTAPPS-DEMO
+  preview:
+    enabled: true
+    aks_name: cft-preview-00-aks
+    aks_resource_group: cft-preview-00-rg
+    aks_subscription: DCD-CFTAPPS-DEV
+  ithc:
+    enabled: true
+    aks_name: cft-ithc-00-aks
+    aks_resource_group: cft-ithc-00-rg
+    aks_subscription: DCD-CFTAPPS-ITHC
+  ptlsbox:
+    enabled: true
+    aks_name: cft-ptlsbox-00-aks
+    aks_resource_group: cft-ptlsbox-00-rg
+    aks_subscription: DTS-CFTSBOX-INTSVC
+  ptl:
+    enabled: true
+    aks_name: cft-ptl-00-aks
+    aks_resource_group: cft-ptl-00-rg
+    aks_subscription: DTS-CFTPTL-INTSVC
+  aat:
+    enabled: true
+    aks_name: cft-aat-00-aks
+    aks_resource_group: cft-aat-00-rg
+    aks_subscription: DCD-CFTAPPS-STG
+  perftest:
+    enabled: true
+    aks_name: cft-perftest-00-aks
+    aks_resource_group: cft-perftest-00-rg
+    aks_subscription: DCD-CFTAPPS-TEST
+  prod:
+    enabled: true
+    aks_name: cft-prod-00-aks
+    aks_resource_group: cft-prod-00-rg
+    aks_subscription: DCD-CFTAPPS-PROD


### PR DESCRIPTION
See:
- https://github.com/hmcts/aks-sds-deploy/pull/292
- https://github.com/hmcts/azure-github-federation-config/pull/15
- https://github.com/hmcts/aks-module-kubernetes/pull/75

We need to manage the permissions in this repo so that if the cluster is rebuilt the permission isn't missing

also ported SDS changes over from CFT so it fetches compatible upgrades only as you can't upgrade across multiple minor versions at a time