### PR TITLE
Revert "Enable workload identity on preview clusters"

### DIFF
--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -2,7 +2,6 @@ cluster_count                      = 2
 kubernetes_cluster_version         = "1.23"
 kubernetes_cluster_ssh_key         = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 enable_user_system_nodepool_split  = true
-workload_identity_enabled          = true
 
 system_node_pool = {
   min_nodes = 2,


### PR DESCRIPTION
Reverts hmcts/aks-cft-deploy#294 - need to run pipeline first to enable OIDC on cluster.