### PR TITLE
Leave SA creation in helm chart control

### DIFF
--- a/bootstrap/deployments/fluxcd/helm-operator-values.yaml
+++ b/bootstrap/deployments/fluxcd/helm-operator-values.yaml
@@ -1,8 +1,6 @@
 workers: 3
 rbac:
   create: false
-serviceAccount:
-  create: false
 helm:
   versions: v3
 git:


### PR DESCRIPTION
I have removed it from flux here : https://github.com/hmcts/cnp-flux-config/pull/18965 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
