### PR TITLE
Add return route nonprod aks

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -72,15 +72,9 @@ additional_routes = [
 ]
 
 additional_routes_appgw = [
- {
-    name                   = "preview"
-    address_prefix         = "10.12.64.0/18"
-    next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.36"
-  },
   {
-    name                   = "core_cftptl_intvsc_vnet"
-    address_prefix         = "10.10.64.0/21"
+    name                   = "core_infra_vnet_idam_aat2"
+    address_prefix         = "10.103.128.0/18"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
   },
@@ -117,6 +111,12 @@ additional_routes_appgw = [
   {
     name                   = "ss-dev-vnet"
     address_prefix         = "10.145.0.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "core_cftptl_intvsc_vnet"
+    address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
   }

--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -72,9 +72,15 @@ additional_routes = [
 ]
 
 additional_routes_appgw = [
+ {
+    name                   = "preview"
+    address_prefix         = "10.12.64.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
   {
-    name                   = "core_infra_vnet_idam_aat2"
-    address_prefix         = "10.103.128.0/18"
+    name                   = "core_cftptl_intvsc_vnet"
+    address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
   },

--- a/environments/network/demo.tfvars
+++ b/environments/network/demo.tfvars
@@ -79,7 +79,7 @@ additional_routes_appgw = [
     address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
-  },
+  }
 ]
 
 additional_routes_coreinfra = [

--- a/environments/network/demo.tfvars
+++ b/environments/network/demo.tfvars
@@ -73,7 +73,13 @@ additional_routes_appgw = [
     address_prefix         = "192.170.0.0/16"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
-  }
+  },
+  {
+    name                   = "core_cftptl_intvsc_vnet"
+    address_prefix         = "10.10.64.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
 ]
 
 additional_routes_coreinfra = [

--- a/environments/network/ithc.tfvars
+++ b/environments/network/ithc.tfvars
@@ -66,6 +66,12 @@ additional_routes_appgw = [
     address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "core_cftptl_intvsc_vnet"
+    address_prefix         = "10.10.64.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -84,6 +84,12 @@ additional_routes_appgw = [
     address_prefix         = "10.141.0.0/18"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "core_cftptl_intvsc_vnet"
+    address_prefix         = "10.10.64.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/sbox.tfvars
+++ b/environments/network/sbox.tfvars
@@ -68,6 +68,12 @@ additional_routes_appgw = [
     address_prefix         = "10.70.24.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.10.200.36"
+  },
+  {
+    name                   = "core_cftptl_intvsc_vnet"
+    address_prefix         = "10.10.64.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 


### PR DESCRIPTION
[DTSPO-11781](https://tools.hmcts.net/jira/browse/DTSPO-11781)

Results not returning from aks to activegates, as a return route is missing from the tables. This adds return routes from aks to the activegate vnet through nonprod palo for nonprod environments, apart from in aat, where it goes through prod palo.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
