### PR TITLE
DTSPO-11755 - fix bootstrap when targeting all clusters in env

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,10 +269,7 @@ stages:
     jobs:
       - job: BootStrap
         variables:
-          ${{ if eq(parameters['cluster'], 'All') }}:
-            clusters: $[ stageDependencies.Aks.DeployInfrastructure.outputs['setClusterNumbers.clusterNumbers'] ]
-          ${{ if ne(parameters['cluster'], 'All') }}:
-            clusters: ${{ parameters.cluster }}
+          clusters: ${{ parameters.cluster }}
         steps:
           - template: pipeline-steps/bootstrap.yaml
             parameters:

--- a/bootstrap/scripts/install-flux.sh
+++ b/bootstrap/scripts/install-flux.sh
@@ -5,6 +5,7 @@ ENV=$3
 CLUSTER_NAME=$6
 FLUX_CONFIG_URL=https://raw.githubusercontent.com/hmcts/cnp-flux-config/master
 AGENT_BUILDDIRECTORY=/tmp
+KUSTOMIZE_VERSION=4.5.7
 
 ############################################################
 # Functions
@@ -99,8 +100,13 @@ function flux_v2_ssh_git_key {
 ############################################################
 
 #Install kustomize
-curl -s "https://raw.githubusercontent.com/\
-kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+
+if [ -f ./kustomize ]; then
+    echo "Kustomize installed"
+else
+    #Install kustomize
+    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s ${KUSTOMIZE_VERSION}
+fi
 
 if [ ${ENV} == "ptlsbox" ]; then
   CLUSTER_ENV="sbox-intsvc"


### PR DESCRIPTION
### Change description ###
Use Az cli to find deployed aks clusters when targeting all clusters in environment
Pin kustomize version to 4.5.7, which is used by the version of flux we currently have deployed - v0.38.3


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
