### PR TITLE
Dtspo 12611 test with module branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,7 @@ stages:
               serviceConnection: $(serviceConnection)
               terraformInitSubscription: ${{ variables.tfInitSub }}
               product: ${{ variables.product }}
-              tfVarsFile: NULL
+              tfVarsFile: "$(System.DefaultWorkingDirectory)/$(buildRepoSuffix)/environments/managed-identity/${{ parameters.env }}.tfvars"
               initCommandOptions: >
                 -var subscription_id=$(ARM_SUBSCRIPTION_ID)
                 -backend-config resource_group_name=$(backendAzureRmResourceGroupName)

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -31,7 +31,7 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 
 module "kubernetes" {
   count  = var.cluster_count
-  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=DTSPO-12611-Test-aso"
+  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
 
   control_resource_group = "azure-control-${local.control_resource_environment}-rg"
   environment            = var.env

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -31,7 +31,7 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 
 module "kubernetes" {
   count  = var.cluster_count
-  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
+  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=DTSPO-12611-Test-aso"
 
   control_resource_group = "azure-control-${local.control_resource_environment}-rg"
   environment            = var.env

--- a/components/managed-identity/inputs-default.tf
+++ b/components/managed-identity/inputs-default.tf
@@ -52,3 +52,7 @@ variable "application_name" {
 variable "expiresAfter" {
   default = "3000-01-01"
 }
+
+variable "service_operator_settings_enabled" {
+  default = false
+}

--- a/components/managed-identity/interpolated-defaults.tf
+++ b/components/managed-identity/interpolated-defaults.tf
@@ -8,6 +8,12 @@ data "azurerm_resource_group" "genesis_rg" {
   name = "genesis-rg"
 }
 
+data "azurerm_subscription" "subscription" {}
+data "azurerm_user_assigned_identity" "aks" {
+  name                = "aks-${var.env}-mi"
+  resource_group_name = data.azurerm_resource_group.genesis_rg.name
+}
+
 locals {
 
   environment = (var.env == "perftest") ? "test" : (var.env == "aat") ? "stg" : (var.env == "ptlsbox") ? "sbox" : (var.env == "preview") ? "dev" : "${var.env}"

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -100,12 +100,6 @@ resource "azurerm_role_assignment" "externaldns_read_rg" {
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
 }
 
-data "azurerm_subscription" "subscription" {}
-
-data "azurerm_user_assigned_identity" "aks" {
-  name                = "aks-${var.env}-mi"
-  resource_group_name = data.azurerm_resource_group.genesis_rg.name
-}
 resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -99,6 +99,22 @@ resource "azurerm_role_assignment" "externaldns_read_rg" {
   role_definition_name = "Reader"
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
 }
+data "azurerm_resource_group" "genesis_rg" {
+  name = "genesis-rg"
+}
+
+data "azurerm_subscription" "subscription" {}
+
+data "azurerm_user_assigned_identity" "aks" {
+  name                = "aks-${var.environment}-mi"
+  resource_group_name = data.azurerm_resource_group.genesis_rg.name
+}
+resource "azurerm_role_assignment" "service_operator" {
+  count                = var.service_operator_settings_enabled ? 1 : 0
+  principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
+  role_definition_name = "Contributor"
+  scope                = data.azurerm_subscription.subscription
+}
 
 module "ctags" {
   source       = "git::https://github.com/hmcts/terraform-module-common-tags.git?ref=master"

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -110,7 +110,7 @@ resource "azurerm_role_assignment" "service_operator" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
-  scope                = data.azurerm_subscription.subscription
+  scope                = data.azurerm_subscription.subscription.id
 }
 
 module "ctags" {

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -103,7 +103,7 @@ resource "azurerm_role_assignment" "externaldns_read_rg" {
 data "azurerm_subscription" "subscription" {}
 
 data "azurerm_user_assigned_identity" "aks" {
-  name                = "aks-${var.environment}-mi"
+  name                = "aks-${var.env}-mi"
   resource_group_name = data.azurerm_resource_group.genesis_rg.name
 }
 resource "azurerm_role_assignment" "service_operator" {

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -99,9 +99,6 @@ resource "azurerm_role_assignment" "externaldns_read_rg" {
   role_definition_name = "Reader"
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
 }
-data "azurerm_resource_group" "genesis_rg" {
-  name = "genesis-rg"
-}
 
 data "azurerm_subscription" "subscription" {}
 

--- a/environments/managed-identity/aat.tfvars
+++ b/environments/managed-identity/aat.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2

--- a/environments/managed-identity/demo.tfvars
+++ b/environments/managed-identity/demo.tfvars
@@ -1,0 +1,2 @@
+cluster_count = 2
+service_operator_settings_enabled = true

--- a/environments/managed-identity/ithc.tfvars
+++ b/environments/managed-identity/ithc.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2

--- a/environments/managed-identity/perftest.tfvars
+++ b/environments/managed-identity/perftest.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2

--- a/environments/managed-identity/preview.tfvars
+++ b/environments/managed-identity/preview.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2

--- a/environments/managed-identity/preview.tfvars
+++ b/environments/managed-identity/preview.tfvars
@@ -1,1 +1,2 @@
 cluster_count = 2
+service_operator_settings_enabled = true

--- a/environments/managed-identity/prod.tfvars
+++ b/environments/managed-identity/prod.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2

--- a/environments/managed-identity/ptl.tfvars
+++ b/environments/managed-identity/ptl.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2

--- a/environments/managed-identity/ptlsbox.tfvars
+++ b/environments/managed-identity/ptlsbox.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 1

--- a/environments/managed-identity/sbox.tfvars
+++ b/environments/managed-identity/sbox.tfvars
@@ -1,0 +1,1 @@
+cluster_count = 2


### PR DESCRIPTION
This change:
- Moves ASO role assignment out from the module and into managed identity stage


In line with proposed module changes here: https://github.com/hmcts/aks-module-kubernetes/pull/85

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
