### PR TITLE
DTSPO-12097-update-ithc-to-1.25

### DIFF
--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -1,5 +1,5 @@
 cluster_count                     = 2
-kubernetes_cluster_version        = "1.24"
+kubernetes_cluster_version        = "1.25"
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUDkk4BOuQmaj4kO5PEyZ1+HR8u2AzRNkmFkICcQWJakXpNvzec+u1s8nSRaWtuZ8ubQwkTluCHY/OxCdmMOxG3K1+t2Dm0edhPTjGwRuRHzFLawEl8OSvMG97hg3aQMtjlflm05Ao2UCNG1wJLJrkiB5RIu2mBvp1hXolQsbTNUhZLDFDLJYRVoF49EzLbxVwM2jSm1hZESeB+BFgcQJQuEe9ORSldSYqK/c3mw+7EqCw3+zFvkN9fS1z9x2Zg2cnnVCLi/HE6Ul/QDD4TBb/1dFXUEZakXId8oP+W8e/2lTbGbjfW4l3ZnFRyT9B1qO5pQZXAE/CapVOVNOzoG6F"
 enable_user_system_nodepool_split = true
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSPO-12097](https://tools.hmcts.net/jira/browse/DTSPO-12097)

### Change description ###

upgrade ithc clusters to 1.25

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
