### PR TITLE
DTSPO-12662 Enable ASO role assignment for workload identity

### DIFF
--- a/components/managed-identity/init.tf
+++ b/components/managed-identity/init.tf
@@ -48,7 +48,7 @@ provider "azurerm" {
   subscription_id            = local.mi_cft[var.env].subscription
   skip_provider_registration = "true"
   features {}
-  alias = "acr"
+  alias = "wi_mapping"
 }
 
 variable "subscription_id" {}

--- a/components/managed-identity/init.tf
+++ b/components/managed-identity/init.tf
@@ -11,45 +11,6 @@ terraform {
     }
   }
 }
-locals {
-  # MIs for managed-identities-sandbox-rg etc - they are RPE MIs
-  mi_cft = {
-    sbox = {
-      subscription = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
-    }
-    perftest = {
-      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
-    }
-    aat = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
-    }
-    ithc = {
-      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
-    }
-    ptlsbox = {
-      subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
-    }
-    preview = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
-    }
-    ptl = {
-      subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-    }
-    prod = {
-      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
-    }
-    demo = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
-    }
-  }
-}
-
-provider "azurerm" {
-  subscription_id            = local.mi_cft[var.env].subscription
-  skip_provider_registration = "true"
-  features {}
-  alias = "wi_mapping"
-}
 
 variable "subscription_id" {}
 

--- a/components/managed-identity/init.tf
+++ b/components/managed-identity/init.tf
@@ -11,6 +11,45 @@ terraform {
     }
   }
 }
+locals {
+  # MIs for managed-identities-sandbox-rg etc - they are RPE MIs
+  mi_cft = {
+    sbox = {
+      subscription = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
+    }
+    perftest = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    aat = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+    ithc = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    ptlsbox = {
+      subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+    }
+    preview = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+    ptl = {
+      subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+    }
+    prod = {
+      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
+    }
+    demo = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id            = local.mi_cft[var.env].subscription
+  skip_provider_registration = "true"
+  features {}
+  alias = "acr"
+}
 
 variable "subscription_id" {}
 

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -56,7 +56,7 @@ locals {
   acme_environment_kv  = var.env == "ptl" ? "ptlintsvc" : var.env == "sandbox" ? "sbox" : var.env == "preview" ? "dev" : var.env == "ptlsbox" ? "sboxintsvc" : var.env == "perftest" ? "test" : var.env == "aat" ? "stg" : var.env
   department_name      = var.env == "ptl" || var.env == "ptlsbox" ? "dts" : "dcd"
   acme_environment_app = var.env == "ptl" || var.env == "ptlsbox" ? "cft" : "cftapps"
-  wi_environment_rg    = var.env == "sbox" ? "sandbox" : var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env
+  wi_environment_rg    = var.env == "sbox" ? "sandbox" : var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "preview" ? "aat" : var.env
 
   external_dns = {
     # Resource Groups to add Reader permissions for external dns to

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -70,6 +70,37 @@ locals {
       "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-idam-demo.internal"
     ])
   }
+
+  # MIs for managed-identities-sandbox-rg etc - they are RPE MIs
+  mi_cft = {
+    sbox = {
+      subscription = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
+    }
+    perftest = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    aat = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+    ithc = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    ptlsbox = {
+      subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+    }
+    preview = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+    ptl = {
+      subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+    }
+    prod = {
+      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
+    }
+    demo = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+  }
 }
 
 data "azurerm_resource_group" "platform-rg" {
@@ -108,10 +139,9 @@ resource "azurerm_role_assignment" "service_operator" {
 }
 resource "azurerm_role_assignment" "service_operator_workload_identity" {
   count                = var.service_operator_settings_enabled ? 1 : 0
-  provider             = azurerm.wi_mapping
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
-  scope                = data.azurerm_subscription.subscription.id
+  scope                = local.mi_cft[var.env].subscription
 }
 
 module "ctags" {

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -109,7 +109,7 @@ resource "azurerm_role_assignment" "service_operator" {
 resource "azurerm_role_assignment" "service_operator_workload_identity" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   provider             = azurerm.wi_mapping
-  principal_id         = data.azurerm_user_assigned_identity.sops_mi.principal_id
+  principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id
 }

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -106,6 +106,13 @@ resource "azurerm_role_assignment" "service_operator" {
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id
 }
+resource "azurerm_role_assignment" "service_operator_workload_identity" {
+  count                = var.service_operator_settings_enabled ? 1 : 0
+  provider             = azurerm.acr
+  principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
+  role_definition_name = "Contributor"
+  scope                = data.azurerm_subscription.subscription.id
+}
 
 module "ctags" {
   source       = "git::https://github.com/hmcts/terraform-module-common-tags.git?ref=master"

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -109,7 +109,7 @@ resource "azurerm_role_assignment" "service_operator" {
 resource "azurerm_role_assignment" "service_operator_workload_identity" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   provider             = azurerm.acr
-  principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
+  principal_id         = data.azurerm_user_assigned_identity.sops_mi.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id
 }

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -56,6 +56,8 @@ locals {
   acme_environment_kv  = var.env == "ptl" ? "ptlintsvc" : var.env == "sandbox" ? "sbox" : var.env == "preview" ? "dev" : var.env == "ptlsbox" ? "sboxintsvc" : var.env == "perftest" ? "test" : var.env == "aat" ? "stg" : var.env
   department_name      = var.env == "ptl" || var.env == "ptlsbox" ? "dts" : "dcd"
   acme_environment_app = var.env == "ptl" || var.env == "ptlsbox" ? "cft" : "cftapps"
+  wi_environment_rg    = var.env == "sbox" ? "sandbox" : var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env
+
   external_dns = {
     # Resource Groups to add Reader permissions for external dns to
     resource_groups = toset([
@@ -74,31 +76,31 @@ locals {
   # MIs for managed-identities-sandbox-rg etc - for workload identity with ASO
   mi_cft = {
     sbox = {
-      scope = "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg"
+      scope = "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783"
     }
     perftest = {
-      scope = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg"
+      scope = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
     }
     aat = {
-      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg"
+      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
     ithc = {
-      scope = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg"
+      scope = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
     }
     ptlsbox = {
-      scope = "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg"
+      scope = "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
     }
     preview = {
-      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg"
+      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
     ptl = {
-      scope = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/managed-identities-cftptl-intsvc-rg"
+      scope = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
     }
     prod = {
-      scope = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg"
+      scope = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1"
     }
     demo = {
-      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg"
+      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
   }
 }
@@ -106,6 +108,7 @@ locals {
 data "azurerm_resource_group" "platform-rg" {
   name = "cft-platform-${local.acme_environment_rg}-rg"
 }
+
 data "azurerm_key_vault" "acme" {
   name                = "acme${local.department_name}${local.acme_environment_app}${local.acme_environment_kv}"
   resource_group_name = data.azurerm_resource_group.platform-rg.name
@@ -141,7 +144,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
-  scope                = local.mi_cft[var.env].scope
+  scope                = "${local.mi_cft[var.env].scope}/resourceGroups/managed-identities-${local.wi_environment_rg}-rg"
 }
 
 module "ctags" {

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -108,7 +108,7 @@ resource "azurerm_role_assignment" "service_operator" {
 }
 resource "azurerm_role_assignment" "service_operator_workload_identity" {
   count                = var.service_operator_settings_enabled ? 1 : 0
-  provider             = azurerm.acr
+  provider             = azurerm.wi_mapping
   principal_id         = data.azurerm_user_assigned_identity.sops_mi.principal_id
   role_definition_name = "Contributor"
   scope                = data.azurerm_subscription.subscription.id

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -74,31 +74,31 @@ locals {
   # MIs for managed-identities-sandbox-rg etc - they are RPE MIs
   mi_cft = {
     sbox = {
-      subscription = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
+      subscription = "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783"
     }
     perftest = {
-      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+      subscription = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
     }
     aat = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      subscription = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
     ithc = {
-      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+      subscription = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
     }
     ptlsbox = {
-      subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+      subscription = "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
     }
     preview = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      subscription = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
     ptl = {
-      subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+      subscription = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
     }
     prod = {
-      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
+      subscription = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1"
     }
     demo = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      subscription = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
   }
 }

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -71,34 +71,34 @@ locals {
     ])
   }
 
-  # MIs for managed-identities-sandbox-rg etc - they are RPE MIs
+  # MIs for managed-identities-sandbox-rg etc - for workload identity with ASO
   mi_cft = {
     sbox = {
-      subscription = "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783"
+      scope = "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg"
     }
     perftest = {
-      subscription = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+      scope = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg"
     }
     aat = {
-      subscription = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg"
     }
     ithc = {
-      subscription = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+      scope = "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg"
     }
     ptlsbox = {
-      subscription = "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+      scope = "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg"
     }
     preview = {
-      subscription = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg"
     }
     ptl = {
-      subscription = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+      scope = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/managed-identities-cftptl-intsvc-rg"
     }
     prod = {
-      subscription = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1"
+      scope = "/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg"
     }
     demo = {
-      subscription = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      scope = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg"
     }
   }
 }
@@ -141,7 +141,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
   count                = var.service_operator_settings_enabled ? 1 : 0
   principal_id         = data.azurerm_user_assigned_identity.aks.principal_id
   role_definition_name = "Contributor"
-  scope                = local.mi_cft[var.env].subscription
+  scope                = local.mi_cft[var.env].scope
 }
 
 module "ctags" {

--- a/environments/managed-identity/sbox.tfvars
+++ b/environments/managed-identity/sbox.tfvars
@@ -1,1 +1,2 @@
-cluster_count = 2
+cluster_count                     = 2
+service_operator_settings_enabled = true


### PR DESCRIPTION
Current error is that the MI doesn't have permission over the subscription, trying this as there's a role assignment of Contributor created in relation to ASO.

https://github.com/hmcts/aks-cft-deploy/blob/45ce763509aa9bdf0cf3a1ca49161158908e3951/components/managed-identity/managed-identity.tf#L103-L108


If that doesn't work, I will add a new role assignment for workload identity instead using the `acr` provider which is set to the infra subscription.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
