### PR TITLE
DTSPO-13332 - add route for ptlsbox to owaspdb

### DIFF
--- a/environments/network/ptlsbox.tfvars
+++ b/environments/network/ptlsbox.tfvars
@@ -39,6 +39,12 @@ additional_routes = [
     address_prefix         = "192.168.0.0/16"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.10.200.36"
+  },
+  {
+    name                   = "owaspdependencycheck"
+    address_prefix         = "10.90.104.17/32"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
   }
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13332

### Change description ###
Add route for ptlsbox to access owaspdependencycheck db on postgres flexible server

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
