### PR TITLE
DTSPO-11646 Switch AKS module to for_each

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -1,11 +1,11 @@
 resource "azurerm_resource_group" "kubernetes_resource_group" {
-  count    = var.cluster_count
+  for_each = toset([for k, v in var.clusters : k])
   location = var.location
 
   name = format("%s-%s-%s-rg",
     var.project,
     var.env,
-    "0${count.index}"
+    each.value
   )
   tags = module.ctags.common_tags
 }
@@ -24,8 +24,8 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 }
 
 module "kubernetes" {
-  count  = var.cluster_count
-  source = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
+  for_each = toset([for k, v in var.clusters : k])
+  source   = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
 
   control_resource_group = "azure-control-${local.control_resource_environment}-rg"
   environment            = var.env
@@ -42,14 +42,13 @@ module "kubernetes" {
     azurerm.global_acr    = azurerm.global_acr
   }
 
-
   resource_group_name = azurerm_resource_group.kubernetes_resource_group[count.index].name
 
   network_name                = local.network_name
   network_shortname           = local.network_shortname
   network_resource_group_name = local.network_resource_group_name
 
-  cluster_number    = "0${count.index}"
+  cluster_number    = each.value
   service_shortname = var.service_shortname
   project           = var.project
 
@@ -65,7 +64,7 @@ module "kubernetes" {
   kubernetes_cluster_agent_min_count = lookup(var.system_node_pool, "min_nodes", 2)
   kubernetes_cluster_agent_max_count = lookup(var.system_node_pool, "max_nodes", 3)
   kubernetes_cluster_agent_vm_size   = lookup(var.system_node_pool, "vm_size", "Standard_DS3_v2")
-  kubernetes_cluster_version         = var.kubernetes_cluster_version
+  kubernetes_cluster_version         = each.value.kubernetes_version
   kubernetes_cluster_agent_max_pods  = var.kubernetes_cluster_agent_max_pods
 
   tags = module.ctags.common_tags

--- a/components/aks/inputs-required.tf
+++ b/components/aks/inputs-required.tf
@@ -13,6 +13,21 @@ variable "control_vault" {}
 # Kubernetes
 variable "kubernetes_cluster_ssh_key" {}
 
+variable "clusters" {
+  type        = map(map(string))
+  description = <<-EOF
+  Map of clusters to manage. Example:
+  clusters = {
+    "00" = {
+      kubernetes_version = "1.22.6"
+    },
+    "01" = {
+      kubernetes_version = "1.22.6"
+    }
+  }
+  EOF
+}
+
 variable "kubernetes_cluster_agent_min_count" {
   default = 1
 }
@@ -22,10 +37,6 @@ variable "kubernetes_cluster_agent_max_count" {
 variable "kubernetes_cluster_agent_vm_size" {
   default = "Standard_DS3_v2"
 }
-
-variable "kubernetes_cluster_version" {}
-
-variable "cluster_count" {}
 
 # CFT specific
 variable "project_acr_enabled" {

--- a/components/aks/outputs.tf
+++ b/components/aks/outputs.tf
@@ -1,9 +1,9 @@
 output "clusters" {
-  value     = join(" ", module.kubernetes[*].cluster)
+  value     = join(" ", flatten([for cluster in module.kubernetes : cluster[*].cluster]))
   sensitive = false
 }
 
 output "kubelet_object_ids" {
-  value     = join(",", module.kubernetes[*].kubelet_object_id)
+  value     = join(",", flatten([for cluster in module.kubernetes : cluster[*].kubelet_object_id]))
   sensitive = false
 }

--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -1,8 +1,13 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDfTT+Bu3rkDptVCj03j8jyflM6bZxNp4tgi0GibRciAops5dOkbtoWKBNpHfGH5AlTKnReRJTlfqM88DjGnYZwYtfx7Kqf3rxNXfwFqXrVYETGy0SNo11WrBSNHDnyfNVm5UFE7HmpSoGVr+C9/OCVmzTDbYoPppGZ79Iv74CLMpsIM8XuD2lQAolODLfA55OTdeJJLgyFu0cEB3ZrrM2DXwMm5CI8C05ACDvDkEO4vtGK9OCYYkxT9/3pskk/ub+IpjuEajryK2fhsPDFwmTVzaMAvM9HIIvDyvfJXjGlGp12d/wubHQ3HlXgUxvU2UF+ggPaaSfQnqALtQ/PwcHf aks-ssh"
 enable_user_system_nodepool_split = true
-
 system_node_pool = {
   vm_size   = "Standard_D4ds_v5",
   min_nodes = 4,

--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUDkk4BOuQmaj4kO5PEyZ1+HR8u2AzRNkmFkICcQWJakXpNvzec+u1s8nSRaWtuZ8ubQwkTluCHY/OxCdmMOxG3K1+t2Dm0edhPTjGwRuRHzFLawEl8OSvMG97hg3aQMtjlflm05Ao2UCNG1wJLJrkiB5RIu2mBvp1hXolQsbTNUhZLDFDLJYRVoF49EzLbxVwM2jSm1hZESeB+BFgcQJQuEe9ORSldSYqK/c3mw+7EqCw3+zFvkN9fS1z9x2Zg2cnnVCLi/HE6Ul/QDD4TBb/1dFXUEZakXId8oP+W8e/2lTbGbjfW4l3ZnFRyT9B1qO5pQZXAE/CapVOVNOzoG6F"
 enable_user_system_nodepool_split = true
 workload_identity_enabled         = true

--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUDkk4BOuQmaj4kO5PEyZ1+HR8u2AzRNkmFkICcQWJakXpNvzec+u1s8nSRaWtuZ8ubQwkTluCHY/OxCdmMOxG3K1+t2Dm0edhPTjGwRuRHzFLawEl8OSvMG97hg3aQMtjlflm05Ao2UCNG1wJLJrkiB5RIu2mBvp1hXolQsbTNUhZLDFDLJYRVoF49EzLbxVwM2jSm1hZESeB+BFgcQJQuEe9ORSldSYqK/c3mw+7EqCw3+zFvkN9fS1z9x2Zg2cnnVCLi/HE6Ul/QDD4TBb/1dFXUEZakXId8oP+W8e/2lTbGbjfW4l3ZnFRyT9B1qO5pQZXAE/CapVOVNOzoG6F"
 enable_user_system_nodepool_split = true
 

--- a/environments/aks/perftest.tfvars
+++ b/environments/aks/perftest.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2lguwg1h0qcaPqPZutQChBAtDK9USDTKNpnY3miVD0cwtFE/Q8U9A3KAfR0wI/WOystKXKGO8e3wq8xf6Pe08aCrbi7X8zIsixKgpQiNXT3j1zRz2Ae4Sa06znSiyzadCv4gSzWsq6m7Sq3FQJ7f2/USDemm1yA0Nena8g73IjxFe0zErqtnRhzicaccxDxaoZNBrfRotV+Nz6FEegUkVnqr+5Jy4H3XvdXfDPc1UzDAn0iBptEW80tcyKZsj7l2Cl20JjnSZ2PwGX/FMzzZIeTtR+eo7/3HxiaZumYAFLcfQ+ZCzId5hA6g30hsSi17HlMco//KkfgReaxXz+gDT aks-ssh"
 enable_user_system_nodepool_split = true
 oms_agent_enabled                 = true

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 enable_user_system_nodepool_split = true
 workload_identity_enabled         = true

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJveNt+D21qfusPdhstV5yLtCK8Wr0eg86iqM9b71ud/U/wb6dO6Pnmw4JiC7EXps17O1TCpfLLOe+rwgLE4LCNVGTqq38HNdiy7VACkNo7xjUmV56URBOds2cCjMiBLfr8iNIa5zrHdtdvImESSH4P13KplyBjlTiHOHnKOQWMgIBD2enbslsJbOcn5p0wxL3QW8z1NNPqZOrEFtkzm8nSrVio2yQo6JXOdb25cy1ecXoJMbXcvkJhxGqKP8mcTbqIkiSKEaamE5hnQFpzUbsmgnZVTINnft3Bu/9iQ8gcSS/sQ4VUy61kU0qIH2FITLntU0Nil0nHCaM3W+Mzmqv aks-ssh"
 enable_user_system_nodepool_split = true
 oms_agent_enabled                 = true

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 1
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"
 ptl_cluster                       = true
 enable_user_system_nodepool_split = true

--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 1
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"
 ptl_cluster                       = true
 enable_user_system_nodepool_split = true

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -1,5 +1,11 @@
-cluster_count                     = 2
-kubernetes_cluster_version        = "1.25"
+clusters = {
+  "00" = {
+    kubernetes_version = "1.25"
+  },
+  "01" = {
+    kubernetes_version = "1.25"
+  }
+}
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCeRwSzSKJfjmIVQ6CUld/M3vF9Hcfxh5cLBa1BV+UZDh5p1gKoB0xRegSFdncfup1qMAhrZtgBpaclLiYUfe8ZajPp1Lmva9AJuK/UktzF9stZie7LDpflEdVBXlSZw3AtAWxF2vIkEeW+NVYlGAJOQlasFkmGTkco+O1wUM4LGI3YNHm7r70rnmHT2djoR1t4x1jlPCrXaJEhvtyxf01Dwjq2nWaox3puJtHs5DLFpEIvXvHwQWssFFyKIuwkm4FewHKJSbCahyaCb+ac10MAZg9vZnWq0EYOe1nLn7c3538yJ9WJh7jRFZDza6ab9HVb5hgJ3/t/K+EzkU/XGSEJ"
 enable_user_system_nodepool_split = true
 project_acr_enabled               = true


### PR DESCRIPTION
This change:
- Updates AKS module to use for_each instead of count
- Enables us to manage each cluster and each cluster k8s version through code


Will also require:
- updatecli updates
- terraform state updates (via move blocks / statemv) - just raising initial code change for now - may be strange pipeline outputs in meantime

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
