### PR TITLE
Remove ptlsbox from main for state move

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ parameters:
     # - sbox
     - perftest
     - aat
-    - ptlsbox
+    # - ptlsbox
     - ptl
     - prod
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-11646

Running TF apply from https://github.com/hmcts/aks-cft-deploy/pull/427 branch, removing env from main during this process to avoid state differences. Will be added back in that PR ^ once all envs done.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
