### PR TITLE
Add-new-ip-subnets-for-jump-box-roues

### DIFF
--- a/environments/network/ptl.tfvars
+++ b/environments/network/ptl.tfvars
@@ -161,6 +161,18 @@ additional_routes = [
     address_prefix         = "10.48.0.32/27"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "jump-box-prod"
+    address_prefix         = "10.24.250.0/26"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "jump-box-nonprod"
+    address_prefix         = "10.25.250.0/26"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13853


### Change description ###
Add in routes for the new prod and non prod jump box subnets


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
