### PR TITLE
Update peering names condition

### DIFF
--- a/components/network/peering.tf
+++ b/components/network/peering.tf
@@ -31,12 +31,12 @@ module "vnet_peer_hub_nonprod" {
 
   peerings = {
     source = {
-      name           = var.env == "ptl" ? "${local.hub["prod"][each.key].peering_name}-nonprod" : local.hub["prod"][each.key].peering_name
+      name           = var.env == "ptl" || var.env == "aat" ? "${local.hub["prod"][each.key].peering_name}-nonprod" : local.hub["prod"][each.key].peering_name
       vnet           = module.network.network_name
       resource_group = module.network.network_resource_group
     }
     target = {
-      name           = (var.env == "aat") ? "${format("%s%s", var.project, var.env)}-nonprod" : format("%s%s", var.project, var.env)
+      name           = format("%s%s", var.project, var.env)
       vnet           = local.hub["nonprod"][each.key].name
       resource_group = local.hub["nonprod"][each.key].name
     }


### PR DESCRIPTION
### Change description ###
Peering names in aat will not be unique with current code
Updating condition to ensure aat environment uses unique peering link names for nonprod and prod

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
