### PR TITLE
ITHC: update ithc-01 AKS version to GA 1.26

### DIFF
--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -3,7 +3,7 @@ clusters = {
     kubernetes_cluster_version = "1.25"
   },
   "01" = {
-    kubernetes_cluster_version = "1.25"
+    kubernetes_cluster_version = "1.26"
   }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUDkk4BOuQmaj4kO5PEyZ1+HR8u2AzRNkmFkICcQWJakXpNvzec+u1s8nSRaWtuZ8ubQwkTluCHY/OxCdmMOxG3K1+t2Dm0edhPTjGwRuRHzFLawEl8OSvMG97hg3aQMtjlflm05Ao2UCNG1wJLJrkiB5RIu2mBvp1hXolQsbTNUhZLDFDLJYRVoF49EzLbxVwM2jSm1hZESeB+BFgcQJQuEe9ORSldSYqK/c3mw+7EqCw3+zFvkN9fS1z9x2Zg2cnnVCLi/HE6Ul/QDD4TBb/1dFXUEZakXId8oP+W8e/2lTbGbjfW4l3ZnFRyT9B1qO5pQZXAE/CapVOVNOzoG6F"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12901


### Change description ###

*  update ithc-01 AKS version to GA 1.26


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
