### PR TITLE
DTSPO-13563 - Add sandbox.platform.hmcts.net as private dns zone

### DIFF
--- a/environments/network/ptl.tfvars
+++ b/environments/network/ptl.tfvars
@@ -16,6 +16,7 @@ additional_subnets = [
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 private_dns_zones = [
+  "sandbox.platform.hmcts.net",
   "aat.platform.hmcts.net",
   "demo.platform.hmcts.net",
   "dev.platform.hmcts.net",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13563


### Change description ###
Add sandbox.platform.hmcts.net as private dns zone


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
