### PR TITLE
DTSPO-15096 Auto-Update OIDC Issuer URL

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -298,6 +298,7 @@ stages:
     dependsOn: Aks
     jobs:
       - job: BootStrap
+        condition: and(succeeded(), eq(variables['isMain'], true), eq('${{ parameters.action }}', 'apply'))
         variables:
           clusters: ${{ parameters.cluster }}
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -293,39 +293,39 @@ stages:
                   -target azurerm_role_assignment.preview2aat_cft_rg_identity_operator["\"${{parameters.cluster}}\""]
                   -target data.azurerm_kubernetes_cluster.kubernetes["\"${{parameters.cluster}}\""]
 
-  - stage: AutoUpdateIssuerURL
-    condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
-    displayName: 'Update Issuer URL'
-    dependsOn: Aks
-    jobs:
-      - job: UpdateURL
-        steps:
-          - checkout: self
-          - checkout: cnp-flux-config
-          - task: AzureKeyVault@1
-            displayName: 'Get secrets from Keyvault'
-            inputs:
-              azureSubscription:  "DTS-CFTPTL-INTSVC"
-              keyVaultName:   "cftptl-intsvc"
-              secretsFilter: 'github-management-api-token'
-          - task: AzureCLI@1
-            displayName: 'Fetch Issuer URL'
-            inputs:
-                azureSubscription: $(serviceConnection)
-                addSpnToEnvironment: true
-                scriptLocation: inlineScript
-                failOnStandardError: 'true'
-                inlineScript: |   
-                  echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n cft-${{ parameters.env }}-${{ parameters.cluster }}-aks -g cft-${{ parameters.env }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
-          - task: Bash@3
-            displayName: 'Update flux-config'
-            inputs:
-              arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config $(github-management-api-token)
-              filePath: aks-cft-deploy/pipeline-scripts/update-issuer-url.sh
+  # - stage: AutoUpdateIssuerURL
+  #   condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
+  #   displayName: 'Update Issuer URL'
+  #   dependsOn: Aks
+  #   jobs:
+  #     - job: UpdateURL
+  #       steps:
+  #         - checkout: self
+  #         - checkout: cnp-flux-config
+  #         - task: AzureKeyVault@1
+  #           displayName: 'Get secrets from Keyvault'
+  #           inputs:
+  #             azureSubscription:  "DTS-CFTPTL-INTSVC"
+  #             keyVaultName:   "cftptl-intsvc"
+  #             secretsFilter: 'github-management-api-token'
+  #         - task: AzureCLI@1
+  #           displayName: 'Fetch Issuer URL'
+  #           inputs:
+  #               azureSubscription: $(serviceConnection)
+  #               addSpnToEnvironment: true
+  #               scriptLocation: inlineScript
+  #               failOnStandardError: 'true'
+  #               inlineScript: |   
+  #                 echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n cft-${{ parameters.env }}-${{ parameters.cluster }}-aks -g cft-${{ parameters.env }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
+  #         - task: Bash@3
+  #           displayName: 'Update flux-config'
+  #           inputs:
+  #             arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config $(github-management-api-token)
+  #             filePath: aks-cft-deploy/pipeline-scripts/update-issuer-url.sh
 
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'
-    dependsOn: AutoUpdateIssuerURL
+    dependsOn: Aks
     jobs:
       - job: BootStrap
         variables:
@@ -334,6 +334,7 @@ stages:
           - template: pipeline-steps/bootstrap.yaml
             parameters:
               environment: ${{ parameters.env }}
+              cluster: ${{ parameters.cluster }}
               project: $(project)
               serviceConnection: $(serviceConnection)
               aksKeyVault: $(aksKeyVault)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -288,9 +288,30 @@ stages:
                   -target azurerm_role_assignment.preview2aat_cft_rg_identity_operator["\"${{parameters.cluster}}\""]
                   -target data.azurerm_kubernetes_cluster.kubernetes["\"${{parameters.cluster}}\""]
 
+  - stage: AutoUpdateIssuerURL
+    # condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
+    displayName: 'Update Issuer URL in Flux'
+    dependsOn: Aks
+    jobs:
+      - job: UpdateURL
+        steps:
+          - task: AzureCLI@1
+            displayName: 'Fetch Issuer URL'
+            inputs:
+                azureSubscription: $(serviceConnection)
+                addSpnToEnvironment: true
+                scriptLocation: inlineScript
+                failOnStandardError: 'true'
+                inlineScript: |   
+                  echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n cft-${{ parameters.env }}-${{ parameters.cluster }}-aks -g cft-${{ parameters.env }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
+          - task: Bash@3
+            inputs:
+              arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL)
+              filePath: $(System.DefaultWorkingDirectory)/pipeline-scripts/update-issuer-url.sh
+
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'
-    dependsOn: Aks
+    dependsOn: AutoUpdateIssuerURL
     jobs:
       - job: BootStrap
         variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -295,6 +295,7 @@ stages:
     jobs:
       - job: UpdateURL
         steps:
+          - checkout: self
           - checkout: cnp-flux-config
           - task: AzureCLI@1
             displayName: 'Fetch Issuer URL'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -298,7 +298,11 @@ stages:
     dependsOn: Aks
     jobs:
       - job: BootStrap
-        condition: and(succeeded(), eq(variables['isMain'], true), eq('${{ parameters.action }}', 'apply'))
+        condition: |
+          or(
+            and(succeeded(), eq('${{ parameters.action }}', 'apply'),
+            and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
+          )
         variables:
           clusters: ${{ parameters.cluster }}
         steps:
@@ -319,7 +323,11 @@ stages:
         pool:
           vmImage: ${{ variables.agentPool }}
         timeoutInMinutes: ${{ variables.timeoutInMinutes }}
-        condition: and(succeeded(), eq(variables['isMain'], true), eq('${{ parameters.action }}', 'apply'))
+        condition: |
+          or(
+            and(succeeded(), eq('${{ parameters.action }}', 'apply'),
+            and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
+          )
         steps:
           - template: steps/pipeline-tests-jest.yaml@cnp-azuredevops-libraries
             parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -294,7 +294,7 @@ stages:
                   -target data.azurerm_kubernetes_cluster.kubernetes["\"${{parameters.cluster}}\""]
 
   - stage: AutoUpdateIssuerURL
-    # condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
+    condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
     displayName: 'Update Issuer URL'
     dependsOn: Aks
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -302,6 +302,12 @@ stages:
         steps:
           - checkout: self
           - checkout: cnp-flux-config
+          - task: AzureKeyVault@1
+            displayName: 'Get secrets from Keyvault'
+            inputs:
+              azureSubscription:  "DTS-CFTPTL-INTSVC"
+              keyVaultName:   "cftptl-intsvc"
+              secretsFilter: 'github-management-api-token'
           - task: AzureCLI@1
             displayName: 'Fetch Issuer URL'
             inputs:
@@ -314,7 +320,7 @@ stages:
           - task: Bash@3
             displayName: 'Update flux-config'
             inputs:
-              arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config
+              arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config $(github-management-api-token)
               filePath: aks-cft-deploy/pipeline-scripts/update-issuer-url.sh
 
   - stage: BootStrapClusters

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,11 @@ resources:
       ref: master
       name: hmcts/cnp-azuredevops-libraries
       endpoint: 'hmcts'
+    - repository: cnp-flux-config
+      type: github
+      ref: refs/heads/master
+      name: hmcts/cnp-flux-config
+      endpoint: 'hmcts'
 
 parameters:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -300,7 +300,7 @@ stages:
       - job: BootStrap
         condition: |
           or(
-            and(succeeded(), eq('${{ parameters.action }}', 'apply'),
+            and(succeeded(), eq('${{ parameters.action }}', 'apply')),
             and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
           )
         variables:
@@ -325,7 +325,7 @@ stages:
         timeoutInMinutes: ${{ variables.timeoutInMinutes }}
         condition: |
           or(
-            and(succeeded(), eq('${{ parameters.action }}', 'apply'),
+            and(succeeded(), eq('${{ parameters.action }}', 'apply')),
             and(succeeded(), eq(variables['isMain'], true), eq(variables['isAutoTriggered'], true))
           )
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -293,36 +293,6 @@ stages:
                   -target azurerm_role_assignment.preview2aat_cft_rg_identity_operator["\"${{parameters.cluster}}\""]
                   -target data.azurerm_kubernetes_cluster.kubernetes["\"${{parameters.cluster}}\""]
 
-  # - stage: AutoUpdateIssuerURL
-  #   condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
-  #   displayName: 'Update Issuer URL'
-  #   dependsOn: Aks
-  #   jobs:
-  #     - job: UpdateURL
-  #       steps:
-  #         - checkout: self
-  #         - checkout: cnp-flux-config
-  #         - task: AzureKeyVault@1
-  #           displayName: 'Get secrets from Keyvault'
-  #           inputs:
-  #             azureSubscription:  "DTS-CFTPTL-INTSVC"
-  #             keyVaultName:   "cftptl-intsvc"
-  #             secretsFilter: 'github-management-api-token'
-  #         - task: AzureCLI@1
-  #           displayName: 'Fetch Issuer URL'
-  #           inputs:
-  #               azureSubscription: $(serviceConnection)
-  #               addSpnToEnvironment: true
-  #               scriptLocation: inlineScript
-  #               failOnStandardError: 'true'
-  #               inlineScript: |   
-  #                 echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n cft-${{ parameters.env }}-${{ parameters.cluster }}-aks -g cft-${{ parameters.env }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
-  #         - task: Bash@3
-  #           displayName: 'Update flux-config'
-  #           inputs:
-  #             arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config $(github-management-api-token)
-  #             filePath: aks-cft-deploy/pipeline-scripts/update-issuer-url.sh
-
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'
     dependsOn: Aks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -290,11 +290,12 @@ stages:
 
   - stage: AutoUpdateIssuerURL
     # condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
-    displayName: 'Update Issuer URL in Flux'
+    displayName: 'Update Issuer URL'
     dependsOn: Aks
     jobs:
       - job: UpdateURL
         steps:
+          - checkout: cnp-flux-config
           - task: AzureCLI@1
             displayName: 'Fetch Issuer URL'
             inputs:
@@ -305,8 +306,9 @@ stages:
                 inlineScript: |   
                   echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n cft-${{ parameters.env }}-${{ parameters.cluster }}-aks -g cft-${{ parameters.env }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
           - task: Bash@3
+            displayName: 'Update flux-config'
             inputs:
-              arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL)
+              arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config
               filePath: $(System.DefaultWorkingDirectory)/pipeline-scripts/update-issuer-url.sh
 
   - stage: BootStrapClusters

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -315,7 +315,7 @@ stages:
             displayName: 'Update flux-config'
             inputs:
               arguments: ${{ parameters.env }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config
-              filePath: $(System.DefaultWorkingDirectory)/pipeline-scripts/update-issuer-url.sh
+              filePath: aks-cft-deploy/pipeline-scripts/update-issuer-url.sh
 
   - stage: BootStrapClusters
     displayName: 'BootStrap Clusters'

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version = "1.26"
+    kubernetes_cluster_version = "1.27"
   },
   "01" = {
     kubernetes_cluster_version = "1.26"

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -14,7 +14,7 @@ if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
-    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 
@@ -25,7 +25,7 @@ if [ -n "$ISSUER_URL" ]; then
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
         git pull origin master --rebase
-        git push --set-upstream origin HEAD:refs/heads/test_issuer_url
+        git push --set-upstream origin HEAD:master
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -5,6 +5,7 @@ ENV=$1
 CLUSTER=$2
 ISSUER_URL=$3
 REPO=$4
+GIT_TOKEN=$5
 
 cd "$REPO"
 
@@ -13,13 +14,17 @@ if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
-    pwd
-    ls
     sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 
         git diff .
+        git config --global user.email github-platform-operations@HMCTS.NET
+        git config --global user.name "hmcts-platform-operations"
+        git add .
+        git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
+        git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
+        git push --dry-run --set-upstream origin HEAD:test_issuer_update
     fi
 fi
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -24,7 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
-        git push --dry-run --set-upstream origin HEAD:master
+        git push --set-upstream origin HEAD:master
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -15,7 +15,7 @@ if [ -n "$ISSUER_URL" ]; then
     file_path="apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
     pwd
     ls
-    sed -i '' "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
+    sed -i "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -25,6 +25,8 @@ if [ -n "$ISSUER_URL" ]; then
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
         git push --dry-run --set-upstream origin HEAD:master
+    else
+        echo "No change to issuer URL, skipping git push..."
     fi
 fi
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -25,7 +25,7 @@ if [ -n "$ISSUER_URL" ]; then
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
         git pull --rebase
-        git push --set-upstream origin HEAD:master
+        git push --set-upstream origin HEAD:refs/heads/test_issuer_url
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -24,7 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
-        git push --dry-run --set-upstream origin HEAD:test_issuer_update
+        git push --dry-run --set-upstream origin HEAD:refs/heads/test_issuer_update
     fi
 fi
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -12,10 +12,10 @@ cd "$REPO"
 if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
-    file_path="apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
+    file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
     pwd
     ls
-    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -14,7 +14,7 @@ if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
-    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\"/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\_test"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 
@@ -25,7 +25,7 @@ if [ -n "$ISSUER_URL" ]; then
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
         git pull --rebase
-        git push --set-upstream origin HEAD:master
+        git push --set-upstream origin HEAD:refs/heads/test_issuer_url
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -24,7 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
-        git pull --rebase
+        git pull origin master --rebase
         git push --set-upstream origin HEAD:refs/heads/test_issuer_url
     else
         echo "No change to issuer URL, skipping git push..."

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -24,6 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
+        git pull --rebase
         git push --set-upstream origin HEAD:master
     else
         echo "No change to issuer URL, skipping git push..."

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -24,7 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
-        git push --set-upstream origin HEAD:master
+        git push --dry-run --set-upstream origin HEAD:master
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -14,6 +14,7 @@ if [ -n "$ISSUER_URL" ]; then
     #  Make file changes
     file_path="cnp-flux-config/apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
     pwd
+    ls
     sed -i '' "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
 
     # Commit changes to github if there is any

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -14,7 +14,7 @@ if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
-    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 
@@ -24,7 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
-        git push --set-upstream origin HEAD:refs/heads/test_issuer_update
+        git push --dry-run --set-upstream origin HEAD:refs/heads/master
     fi
 fi
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -15,7 +15,7 @@ if [ -n "$ISSUER_URL" ]; then
     file_path="apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
     pwd
     ls
-    sed -i "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -14,7 +14,7 @@ if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
-    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\_test"/g" $file_path
+    sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')_test\"/g" $file_path
 
     # Commit changes to github if there is any
     if [[ -n $(git status -s) ]]; then 
@@ -25,7 +25,7 @@ if [ -n "$ISSUER_URL" ]; then
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
         git pull --rebase
-        git push --set-upstream origin HEAD:refs/heads/test_issuer_url
+        git push --set-upstream origin HEAD:master
     else
         echo "No change to issuer URL, skipping git push..."
     fi

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -12,7 +12,7 @@ cd "$REPO"
 if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
-    file_path="cnp-flux-config/apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
+    file_path="apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
     pwd
     ls
     sed -i '' "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -4,13 +4,22 @@ set -e
 ENV=$1
 CLUSTER=$2
 ISSUER_URL=$3
+REPO=$4
 
-echo "Issuer URL is: ${ISSUER_URL}"
+cd "$REPO"
 
-# Check ISSUER url is set
-
-# log in as account which has access for github
-# Update file in place apps/flux-system/ENV/CLUSTER/kustomize.yaml
 # Update after ISSUER_URL: 
+if [ -n "$ISSUER_URL" ]; then
+    echo "Issuer URL is: ${ISSUER_URL}"
+    #  Make file changes
+    file_path="apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
+    sed -i '' "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
+
+    # Commit changes to github if there is any
+    if [[ -n $(git status -s) ]]; then 
+        git diff .
+    fi
+fi
+
 
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+ENV=$1
+CLUSTER=$2
+ISSUER_URL=$3
+
+echo "Issuer URL is: ${ISSUER_URL}"
+
+# Check ISSUER url is set
+
+# log in as account which has access for github
+# Update file in place apps/flux-system/ENV/CLUSTER/kustomize.yaml
+# Update after ISSUER_URL: 
+
+

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -24,7 +24,7 @@ if [ -n "$ISSUER_URL" ]; then
         git add .
         git commit -m "Updating OIDC Issuer URL for $CLUSTER cluster in $ENV"
         git remote set-url origin https://hmcts-platform-operations:"${GIT_TOKEN}"@github.com/hmcts/"$REPO".git
-        git push --dry-run --set-upstream origin HEAD:refs/heads/test_issuer_update
+        git push --set-upstream origin HEAD:refs/heads/test_issuer_update
     fi
 fi
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -12,7 +12,8 @@ cd "$REPO"
 if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
-    file_path="apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
+    file_path="cnp-flux-config/apps/flux-system/$ENV/$CLUSTER/kustomize.yaml"
+    pwd
     sed -i '' "s/ISSUER_URL:.*/ISSUER_URL: ${ISSUER_URL}_test/g" $file_path
 
     # Commit changes to github if there is any

--- a/pipeline-steps/bootstrap.yaml
+++ b/pipeline-steps/bootstrap.yaml
@@ -5,7 +5,8 @@ parameters:
   terraformSubscriptionID: ''
 
 steps:
-
+- checkout: self
+- checkout: cnp-flux-config
 - template: steps/keyvault-read.yaml@cnp-azuredevops-libraries
   parameters:
     serviceConnection: $(serviceConnection)
@@ -21,6 +22,20 @@ steps:
       failOnStandardError: 'true'
       inlineScript: |   
         echo "##vso[task.setvariable variable=AZURE_MI_ID]$(az identity show --resource-group genesis-rg --name aks-$(env)-mi --query="clientId" -o tsv)"
+        echo "##vso[task.setvariable variable=AKS_ISSUER_URL]$(az aks show -n cft-${{ parameters.environment }}-${{ parameters.cluster }}-aks -g cft-${{ parameters.environment }}-${{ parameters.cluster }}-rg --query "oidcIssuerProfile.issuerUrl" -otsv)"
+
+- task: AzureKeyVault@1
+  displayName: 'Get secrets from Keyvault'
+  inputs:
+    azureSubscription:  "DTS-CFTPTL-INTSVC"
+    keyVaultName:   "cftptl-intsvc"
+    secretsFilter: 'github-management-api-token'
+
+- task: Bash@3
+  displayName: 'Update flux-config'
+  inputs:
+    arguments: ${{ parameters.environment }} ${{ parameters.cluster }} $(AKS_ISSUER_URL) cnp-flux-config $(github-management-api-token)
+    filePath: aks-cft-deploy/pipeline-scripts/update-issuer-url.sh
 
 - task: AzureCLI@1
   displayName: 'Bootstrap'

--- a/pipeline-steps/bootstrap.yaml
+++ b/pipeline-steps/bootstrap.yaml
@@ -45,5 +45,5 @@ steps:
     addSpnToEnvironment: true
     scriptType: shell
     failOnStandardError: 'false'
-    scriptPath: bootstrap/bootstrap.sh
+    scriptPath: aks-cft-deploy/bootstrap/bootstrap.sh
     arguments: ${{ parameters.project }} aks $(env) $(controlKeyVault) $(serviceConnection) "$(clusters)" deploy ${{ parameters.akskeyvault }} ${{parameters.terraformSubscriptionID}}

--- a/pipeline-steps/bootstrap.yaml
+++ b/pipeline-steps/bootstrap.yaml
@@ -14,7 +14,6 @@ steps:
 
 - task: AzureCLI@1
   displayName: 'Setup Authentication'
-  condition: and(variables.isMain, eq(variables['Action'], 'Apply'))
   inputs:
       azureSubscription: $(serviceConnection)
       addSpnToEnvironment: true
@@ -39,7 +38,6 @@ steps:
 
 - task: AzureCLI@1
   displayName: 'Bootstrap'
-  condition: and(variables.isMain, true, eq(variables['action'], 'apply'))
   inputs:
     azureSubscription: $(serviceConnection)
     addSpnToEnvironment: true


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15096

This change:
 - Adds functionality for automatically updating the OIDC Issuer URL in flux during the aks-cft-deploy pipeline, which is necessary when a cluster is **rebuilt**, due to workload identity work
 - Bootstrapping clusters is now dependent on this stage having run (even if it produces no changes)
- Example of pushing a test URL to test branch in flux instead of master listed below:

![image](https://github.com/hmcts/aks-cft-deploy/assets/47995122/1a306991-2bc4-4989-8b46-4150ffd91ab6)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
