### PR TITLE
Update to fix for ptl and ptlsbox with ternary

### DIFF
--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -13,7 +13,7 @@ cd "$REPO"
 if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
-    ENV=$([[ "$ENV" == "ptl" ]] && echo "ptl-intsvc" || ( [[ "$ENV" == "ptlsbox" ]] && echo "sbox-intsvc" || echo "$ENV" ))
+    ENV=$([[ "$ENV" == "ptl" ]] && echo "ptl-intsvc" || ([[ "$ENV" == "ptlsbox" ]] && echo "sbox-intsvc" || echo "$ENV" ))
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
     sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\"/g" $file_path
 

--- a/pipeline-scripts/update-issuer-url.sh
+++ b/pipeline-scripts/update-issuer-url.sh
@@ -13,6 +13,7 @@ cd "$REPO"
 if [ -n "$ISSUER_URL" ]; then
     echo "Issuer URL is: ${ISSUER_URL}"
     #  Make file changes
+    ENV=$([[ "$ENV" == "ptl" ]] && echo "ptl-intsvc" || ( [[ "$ENV" == "ptlsbox" ]] && echo "sbox-intsvc" || echo "$ENV" ))
     file_path="apps/flux-system/${ENV}/${CLUSTER}/kustomize.yaml"
     sed -i -e "s/ISSUER_URL:.*/ISSUER_URL: \"$(echo $ISSUER_URL | sed 's/[\/&]/\\&/g')\"/g" $file_path
 


### PR DESCRIPTION
folders are name as ptl-intsvc and sbox-intsvc in flux, but envs are named as ptl, and ptlsbox in ADO

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
