### PR TITLE
Add role assignment back

### DIFF
--- a/components/aks-mis/cft_aks.tf
+++ b/components/aks-mis/cft_aks.tf
@@ -3,3 +3,16 @@ data "azurerm_kubernetes_cluster" "kubernetes" {
   name                = "${var.project}-${var.env}-${each.key}-${var.service_shortname}"
   resource_group_name = "${var.project}-${var.env}-${each.key}-rg"
 }
+
+data "azurerm_resource_group" "managed-identity-operator-cft-mi" {
+  provider = azurerm.acr
+  name     = "managed-identities-${local.environment}-rg"
+}
+
+resource "azurerm_role_assignment" "uami_cft_rg_identity_operator" {
+  for_each             = toset(var.clusters)
+  provider             = azurerm.acr
+  principal_id         = data.azurerm_kubernetes_cluster.kubernetes[each.key].kubelet_identity[0].object_id
+  scope                = data.azurerm_resource_group.managed-identity-operator-cft-mi.id
+  role_definition_name = "Managed Identity Operator"
+}


### PR DESCRIPTION
This was removed from the aks module in https://github.com/hmcts/aks-module-kubernetes/pull/95#event-10644661194
But also removed from here in https://github.com/hmcts/aks-cft-deploy/pull/560 incorrectly

In this repo, it uses the infra sub provider which is the correct RG -- adding this back in so it stops trying to be deleted

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
