### PR TITLE
DTSPO-12677 Remove external-dns from demo, add roles for preview admin-mi

### DIFF
--- a/components/aks-mis/cft_aks.tf
+++ b/components/aks-mis/cft_aks.tf
@@ -3,3 +3,16 @@ data "azurerm_kubernetes_cluster" "kubernetes" {
   name                = "${var.project}-${var.env}-${each.key}-${var.service_shortname}"
   resource_group_name = "${var.project}-${var.env}-${each.key}-rg"
 }
+
+data "azurerm_resource_group" "managed-identity-operator-cft-mi" {
+  provider = azurerm.acr
+  name     = "managed-identities-${local.environment}-rg"
+}
+
+resource "azurerm_role_assignment" "uami_cft_rg_identity_operator" {
+  for_each             = toset(var.clusters)
+  provider             = azurerm.acr
+  principal_id         = data.azurerm_kubernetes_cluster.kubernetes[each.key].kubelet_identity[0].object_id
+  scope                = data.azurerm_resource_group.managed-identity-operator-cft-mi.id
+  role_definition_name = "Managed Identity Operator"
+}

--- a/components/managed-identity/init.tf
+++ b/components/managed-identity/init.tf
@@ -20,6 +20,13 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  alias                      = "dts-cftptl-intsvc"
+  skip_provider_registration = "true"
+  features {}
+  subscription_id = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+}
+
+provider "azurerm" {
   subscription_id            = local.mi_cft[var.env].subscription_id
   skip_provider_registration = "true"
   features {}

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -147,6 +147,22 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
   scope                = "/subscriptions/${local.mi_cft[var.env].subscription_id}/resourceGroups/managed-identities-${local.wi_environment_rg}-rg"
 }
 
+resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
+  count                = (contains(["preview"], var.env) ? 1 : 0)
+  provider             = azurerm.dts-cftptl-intsvc
+  principal_id         = data.azurerm_user_assigned_identity.wi-admin-mi.principal_id
+  scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg"
+  role_definition_name = "Reader"
+}
+
+resource "azurerm_role_assignment" "preview_admin_mi_externaldns_dns_zone_contributor" {
+  count                = (contains(["preview"], var.env) ? 1 : 0)
+  provider             = azurerm.dts-cftptl-intsvc
+  principal_id         = data.azurerm_user_assigned_identity.wi-admin-mi.principal_id
+  scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
+  role_definition_name = "Private DNS Zone Contributor"
+}
+
 module "ctags" {
   source       = "git::https://github.com/hmcts/terraform-module-common-tags.git?ref=master"
   environment  = var.env

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -58,21 +58,6 @@ locals {
   acme_environment_app = var.env == "ptl" || var.env == "ptlsbox" ? "cft" : "cftapps"
   wi_environment_rg    = var.env == "sbox" ? "sandbox" : var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "preview" ? "aat" : var.env
 
-  external_dns = {
-    # Resource Groups to add Reader permissions for external dns to
-    resource_groups = toset([
-      "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtRG",
-      "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg"
-    ])
-    # Demo DNS zones to add "DNS Zone Contributor" premissions for external dns to
-    demo = toset([
-      "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtRG/providers/Microsoft.Network/dnszones/demo.platform.hmcts.net",
-      "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/demo.platform.hmcts.net",
-      "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-demo.internal",
-      "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-idam-demo.internal"
-    ])
-  }
-
   # MIs for managed-identities-sandbox-rg etc - for workload identity with ASO
   mi_cft = {
     # DCD-CNP-Sandbox
@@ -139,21 +124,6 @@ resource "azurerm_role_assignment" "acme-vault-access" {
   scope                = data.azurerm_key_vault.acme.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = each.key
-}
-
-resource "azurerm_role_assignment" "externaldns_dns_zone_contributor" {
-  for_each             = lookup(local.external_dns, var.env, toset([]))
-  scope                = each.value
-  role_definition_name = contains(regex("^.*/Microsoft.Network/(.*)/.*$", each.value), "privateDnsZones") ? "Private DNS Zone Contributor" : "DNS Zone Contributor"
-  principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
-}
-
-resource "azurerm_role_assignment" "externaldns_read_rg" {
-  # Only add the reader role if there are zones configured
-  for_each             = lookup(local.external_dns, var.env, null) != null ? local.external_dns.resource_groups : toset([])
-  scope                = each.value
-  role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
 }
 
 resource "azurerm_role_assignment" "service_operator" {

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -58,6 +58,9 @@ locals {
   acme_environment_app = var.env == "ptl" || var.env == "ptlsbox" ? "cft" : "cftapps"
   wi_environment_rg    = var.env == "sbox" ? "sandbox" : var.env == "ptlsbox" ? "cftsbox-intsvc" : var.env == "ptl" ? "cftptl-intsvc" : var.env == "preview" ? "aat" : var.env
 
+  # This is needed for external DNS preview role assignments which uses aat-mi
+  admin_aat_mi = "1c09e6f2-45f5-4d09-99a2-a6a36e719239"
+
   # MIs for managed-identities-sandbox-rg etc - for workload identity with ASO
   mi_cft = {
     # DCD-CNP-Sandbox
@@ -148,7 +151,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
 }
 
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
-  count                = (contains(["preview"], var.env) ? 1 : 0)
+  for_each             = var.env == "preview" ? toset(local.admin_aat_mi) : []
   provider             = azurerm.dts-cftptl-intsvc
   principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
   scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg"
@@ -156,7 +159,7 @@ resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
 }
 
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_dns_zone_contributor" {
-  count                = (contains(["preview"], var.env) ? 1 : 0)
+  for_each             = var.env == "preview" ? toset(local.admin_aat_mi) : []
   provider             = azurerm.dts-cftptl-intsvc
   principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
   scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -150,7 +150,7 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
   count                = (contains(["preview"], var.env) ? 1 : 0)
   provider             = azurerm.dts-cftptl-intsvc
-  principal_id         = data.azurerm_user_assigned_identity.wi-admin-mi.principal_id
+  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
   scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg"
   role_definition_name = "Reader"
 }
@@ -158,7 +158,7 @@ resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_dns_zone_contributor" {
   count                = (contains(["preview"], var.env) ? 1 : 0)
   provider             = azurerm.dts-cftptl-intsvc
-  principal_id         = data.azurerm_user_assigned_identity.wi-admin-mi.principal_id
+  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
   scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
   role_definition_name = "Private DNS Zone Contributor"
 }

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -151,17 +151,17 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
 }
 
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
-  for_each             = var.env == "preview" ? toset(local.admin_aat_mi) : []
+  count                = var.env == "preview" ? 1 : 0
   provider             = azurerm.dts-cftptl-intsvc
-  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
+  principal_id         = local.admin_aat_mi
   scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg"
   role_definition_name = "Reader"
 }
 
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_dns_zone_contributor" {
-  for_each             = var.env == "preview" ? toset(local.admin_aat_mi) : []
+  count                = var.env == "preview" ? 1 : 0
   provider             = azurerm.dts-cftptl-intsvc
-  principal_id         = azurerm_user_assigned_identity.wi-admin-mi.principal_id
+  principal_id         = local.admin_aat_mi
   scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
   role_definition_name = "Private DNS Zone Contributor"
 }


### PR DESCRIPTION
We no longer use the deleted changes in demo since a move to active-active -- and it's not destroying anything in preview where we do use external-dns..

Adds similar role assignments that already exist in https://github.com/hmcts/aks-cft-deploy/blob/main/components/aks-mis/preview.tf#L36-L50 but for the new admin-mis - as done in SDS

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
