### PR TITLE
Update to include preview.platform.hmcts.net zone

### DIFF
--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -62,12 +62,8 @@ locals {
   admin_aat_mi = "79779e13-763e-4445-990d-a2509eb96773"
 
   external_dns_zones = {
-    preview-platform-hmcts-net = {
-      id = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/preview.platform.hmcts.net"
-    }
-    preview-internal = {
-      id = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
-    }
+    preview-platform-hmcts-net =  "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/preview.platform.hmcts.net",
+    preview-internal = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
   }
 
   # MIs for managed-identities-sandbox-rg etc - for workload identity with ASO
@@ -168,10 +164,10 @@ resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
 }
 
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_dns_zone_contributor" {
-  for_each             = var.env == "preview" ? toset(local.external_dns_zones) : []
+  for_each             = var.env == "preview" ? local.external_dns_zones : {}
   provider             = azurerm.dts-cftptl-intsvc
   principal_id         = local.admin_aat_mi
-  scope                = each.value["id"]
+  scope                = each.value
   role_definition_name = "Private DNS Zone Contributor"
 }
 

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -62,8 +62,8 @@ locals {
   admin_aat_mi = "79779e13-763e-4445-990d-a2509eb96773"
 
   external_dns_zones = {
-    preview-platform-hmcts-net =  "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/preview.platform.hmcts.net",
-    preview-internal = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
+    preview-platform-hmcts-net = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/preview.platform.hmcts.net",
+    preview-internal           = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/service.core-compute-preview.internal"
   }
 
   # MIs for managed-identities-sandbox-rg etc - for workload identity with ASO

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -160,12 +160,13 @@ resource "azurerm_role_assignment" "service_operator_workload_identity" {
 }
 
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_read_rg" {
-  for_each             = var.env == "preview" ? toset(local.external_dns_zones) : []
+  count                = var.env == "preview" ? 1 : 0
   provider             = azurerm.dts-cftptl-intsvc
   principal_id         = local.admin_aat_mi
-  scope                = each.value["id"]
+  scope                = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg"
   role_definition_name = "Reader"
 }
+
 resource "azurerm_role_assignment" "preview_admin_mi_externaldns_dns_zone_contributor" {
   for_each             = var.env == "preview" ? toset(local.external_dns_zones) : []
   provider             = azurerm.dts-cftptl-intsvc


### PR DESCRIPTION
Already added this for the .internal URL - but the existing `aks-preview-mi` also has dns zone contributor permissions within this zone -- updating the code to add this permission also for admin-aat-mi for external-dns



<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
