### PR TITLE
Disable AKS diagnostics in nonprod

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -25,7 +25,7 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 
 module "kubernetes" {
   for_each = toset([for key, value in var.clusters : key])
-  source   = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=spot"
+  source   = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
 
   control_resource_group = "azure-control-${local.control_resource_environment}-rg"
   environment            = var.env

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -52,8 +52,10 @@ module "kubernetes" {
   service_shortname = var.service_shortname
   project           = var.project
 
-  log_workspace_id           = module.loganalytics.workspace_id
-  monitor_diagnostic_setting = var.monitor_diagnostic_setting
+  log_workspace_id                   = module.loganalytics.workspace_id
+  monitor_diagnostic_setting         = var.monitor_diagnostic_setting
+  monitor_diagnostic_setting_metrics = var.monitor_diagnostic_setting_metrics
+  kube_audit_admin_logs_enabled      = var.kube_audit_admin_logs_enabled
 
   control_vault = var.control_vault
 

--- a/components/aks/inputs-required.tf
+++ b/components/aks/inputs-required.tf
@@ -47,6 +47,14 @@ variable "monitor_diagnostic_setting" {
   default = false
 }
 
+variable "kube_audit_admin_logs_enabled" {
+  default = false
+}
+
+variable "monitor_diagnostic_setting_metrics" {
+  default = false
+}
+
 variable "sku_tier" {
   default = "Standard"
 }

--- a/components/aks/inputs-required.tf
+++ b/components/aks/inputs-required.tf
@@ -44,7 +44,7 @@ variable "project_acr_enabled" {
 }
 
 variable "monitor_diagnostic_setting" {
-  default = true
+  default = false
 }
 
 variable "sku_tier" {

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -20,6 +20,8 @@ linux_node_pool = {
   max_nodes = 100
 }
 
-monitor_diagnostic_setting = true
+monitor_diagnostic_setting         = true
+monitor_diagnostic_setting_metrics = true
+kube_audit_admin_logs_enabled      = true
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -20,4 +20,6 @@ linux_node_pool = {
   max_nodes = 100
 }
 
+monitor_diagnostic_setting = true
+
 availability_zones = ["1", "2", "3"]


### PR DESCRIPTION
I'm seeing stupidly high logs at least in preview.

I don't think we ever use these logs at all so why not turn them off?

https://portal.azure.com#@531ff96d-0ae9-462a-8d2d-bec7c0b42082/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2F1c4f0704-a29e-403d-b719-b90c34ef14c9%2Fresourcegroups%2Foms-automation%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fhmcts-nonprod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA12MsQqDMBRF937Fw0lBoX6AQ7C2lC7Fip1j8ogBk8BLQlH68U3WbhfuOYcdkfCiubLOBy08nL7wWZEQRvQukkDoOij669Q8x2G%252BD%252B%252Fm3Dbs8SoS6KMxnPSBwJQiVDygnPkWkwPCRRvKCpYdFm3LSRu8oUXKTA2trGro01aO9lxyFDL635HoRboJrURKzS0aK1ZO4QfkshPiuAAAAA%253D%253D/timespan/P7D