### PR TITLE
Update aat, prod, perftest with new postgres-extended subnet

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -16,6 +16,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.10.164.0/22"
   },
+  {
+    name           = "postgres-expanded"
+    address_prefix = "10.10.172.0/22"
+  }
 ]
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -16,6 +16,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.48.100.0/22"
   },
+  {
+    name           = "postgres-expanded"
+    address_prefix = "10.48.108.0/22"
+  }
 ]
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"

--- a/environments/network/prod.tfvars
+++ b/environments/network/prod.tfvars
@@ -16,6 +16,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.90.100.0/22"
   },
+  {
+    name           = "postgres-expanded"
+    address_prefix = "10.90.108.0/22"
+  }
 ]
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"


### PR DESCRIPTION
### Change description ###
Update aat, prod, perftest with new postgres-extended subnet.

Existing endpoint filled up due to HA flexible postgres requiring 4 IP addresses per server:
https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking#virtual-network-concepts
