### PR TITLE
DTSPO-15888 Fix developer group name

### DIFF
--- a/components/genesis/inputs-default.tf
+++ b/components/genesis/inputs-default.tf
@@ -2,7 +2,7 @@ locals {
 
   environment = (var.env == "aat") ? "stg" : (var.env == "perftest") ? "test" : (var.env == "preview") ? "dev" : var.env
 
-  developers_group = "DTS Operations (env:${local.environment})"
+  developers_group = "DTS CFT Developers"
 
   business_area = "cft"
 


### PR DESCRIPTION
### Jira link (if applicable)
[DTSPO-15888](https://tools.hmcts.net/jira/browse/DTSPO-15888)


### Change description ###

For some reason this is not using the developers groups which prevents developers from encrypting with SOPS

they can't decrypt, only encrypt:

https://github.com/hmcts/aks-module-genesis/blob/master/20-key-vault.tf#L59-L73

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
