### PR TITLE
Added mi-vnet-test and mi-vnet-ithc PTL routes

### DIFF
--- a/environments/network/ptl.tfvars
+++ b/environments/network/ptl.tfvars
@@ -185,13 +185,24 @@ additional_routes = [
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   },
-
-    {
-      name                   = "bias-storage"
-      address_prefix         = "10.225.251.96/29"
-      next_hop_type          = "VirtualAppliance"
-      next_hop_in_ip_address = "10.11.72.36"
-    }
+  {
+    name                   = "mi-vnet-test"
+    address_prefix         = "10.168.2.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "mi-vnet-ithc"
+    address_prefix         = "10.168.4.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "bias-storage"
+    address_prefix         = "10.225.251.96/29"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  }
 ]
 
 additional_routes_coreinfra = [


### PR DESCRIPTION
Needed for connection from non-prod AKS build agents to resources in the mi-vnet-test and mi-vnet-ithc vnet.