### PR TITLE
Adding spot_node_pool variable and lookups to allow per environment settings for vm size, min/max scaling and max pod count per host

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -98,10 +98,10 @@ module "kubernetes" {
     },
     {
       name                = "spotinstance"
-      vm_size             = "Standard_D4ds_v5"
-      min_count           = 0
-      max_count           = 10
-      max_pods            = 30
+      vm_size             = lookup(var.spot_node_pool, "vm_size", "Standard_D4ds_v5")
+      min_count           = lookup(var.spot_node_pool, "min_nodes", 0)
+      max_count           = lookup(var.spot_node_pool, "max_nodes", 5)
+      max_pods            = lookup(var.spot_node_pool, "max_pods", 30)
       os_type             = "Linux"
       node_taints         = ["kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
       enable_auto_scaling = true

--- a/components/aks/inputs-default.tf
+++ b/components/aks/inputs-default.tf
@@ -18,6 +18,10 @@ variable "linux_node_pool" {
   description = "Map to override the linux node pool config"
 }
 
+variable "spot_node_pool" {
+  description = "Map to override the spot node pool config"
+}
+
 variable "kubernetes_cluster_agent_max_pods" {
   default = "30"
 }

--- a/components/aks/inputs-default.tf
+++ b/components/aks/inputs-default.tf
@@ -20,6 +20,7 @@ variable "linux_node_pool" {
 
 variable "spot_node_pool" {
   description = "Map to override the spot node pool config"
+  default     = {}
 }
 
 variable "kubernetes_cluster_agent_max_pods" {

--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -14,11 +14,18 @@ system_node_pool = {
   min_nodes = 4,
   max_nodes = 10
 }
+
 linux_node_pool = {
   vm_size   = "Standard_D8ds_v5",
   min_nodes = 20,
   max_nodes = 30,
   max_pods  = 50
+}
+
+spot_node_pool = {
+  vm_size   = "Standard_D8ds_v5",
+  min_nodes = 1,
+  max_nodes = 10
 }
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -25,7 +25,8 @@ linux_node_pool = {
 spot_node_pool = {
   vm_size   = "Standard_D8ds_v5",
   min_nodes = 1,
-  max_nodes = 10
+  max_nodes = 30,
+  max_pods  = 50
 }
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -25,8 +25,7 @@ linux_node_pool = {
 }
 
 spot_node_pool = {
-  min_nodes = 1,
-  max_nodes = 10
+  min_nodes = 1
 }
 
 availability_zones = ["1"]

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -17,9 +17,15 @@ system_node_pool = {
   min_nodes = 2,
   max_nodes = 4
 }
+
 linux_node_pool = {
   vm_size   = "Standard_D4ds_v5",
   min_nodes = 4,
+  max_nodes = 10
+}
+
+spot_node_pool = {
+  min_nodes = 1,
   max_nodes = 10
 }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16162


### Change description ###
Adding spot_node_pool variable and lookups to allow per environment settings for vm size, min/max scaling and max pod count per host

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines