### PR TITLE
DTSPO-16593 - correcting k8s version

### DIFF
--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version = "1.29.2"
+    kubernetes_cluster_version = "1.29"
   },
   # "01" = {
   #   kubernetes_cluster_version = "1.25"

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -1,16 +1,16 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version = "1.29.2"
+    kubernetes_cluster_version = "1.29"
   },
   "01" = {
-    kubernetes_cluster_version = "1.29.2"
+    kubernetes_cluster_version = "1.29"
   }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCeRwSzSKJfjmIVQ6CUld/M3vF9Hcfxh5cLBa1BV+UZDh5p1gKoB0xRegSFdncfup1qMAhrZtgBpaclLiYUfe8ZajPp1Lmva9AJuK/UktzF9stZie7LDpflEdVBXlSZw3AtAWxF2vIkEeW+NVYlGAJOQlasFkmGTkco+O1wUM4LGI3YNHm7r70rnmHT2djoR1t4x1jlPCrXaJEhvtyxf01Dwjq2nWaox3puJtHs5DLFpEIvXvHwQWssFFyKIuwkm4FewHKJSbCahyaCb+ac10MAZg9vZnWq0EYOe1nLn7c3538yJ9WJh7jRFZDza6ab9HVb5hgJ3/t/K+EzkU/XGSEJ"
 enable_user_system_nodepool_split = true
 project_acr_enabled               = true
 
-enable_automatic_channel_upgrade_patch = false
+enable_automatic_channel_upgrade_patch = true
 
 system_node_pool = {
   vm_size   = "Standard_D4ds_v5",


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16593

### Change description ###

According to documentation here, we should only upgrade to major version, the minor GA patch version will automatically selected by Terraform.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#kubernetes_version

