### PR TITLE
Revert "add preview-01"

### DIFF
--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -3,9 +3,9 @@ clusters = {
     kubernetes_cluster_version = "1.29"
   },
 
-  "01" = {
-    kubernetes_cluster_version = "1.29"
-  }
+  # "01" = {
+  #   kubernetes_cluster_version = "1.29"
+  # }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 enable_user_system_nodepool_split = true


### PR DESCRIPTION
Testing complete, removing preview01

## 🤖AEP PR SUMMARY🤖


### environments/aks/preview.tfvars
- Removed a cluster entry with key \"01\" and its associated kubernetes_cluster_version.
- Cleared unnecessary \"+\" signs that were added as a result of the removal.
- Replaced the aks-ssh key with a new value.