### PR TITLE
Add missing routes to dynatrace

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -156,6 +156,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/demo.tfvars
+++ b/environments/network/demo.tfvars
@@ -80,6 +80,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/ithc.tfvars
+++ b/environments/network/ithc.tfvars
@@ -73,6 +73,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -97,6 +97,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/preview.tfvars
+++ b/environments/network/preview.tfvars
@@ -71,6 +71,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.72.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 

--- a/environments/network/sbox.tfvars
+++ b/environments/network/sbox.tfvars
@@ -75,6 +75,12 @@ additional_routes_application_gateway = [
     address_prefix         = "10.10.64.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dynatrace-nonprod-vnet"
+    address_prefix         = "10.10.80.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 


### PR DESCRIPTION
### Change description ###
Dynatrace routes were missing on nonprod aks route tables
Connections from dynatrace activegates were reaching applications on the clusters but could not make their way back
This will fix alerts and errors occurring in nonprod dynatrace

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- The following files have all been updated (aat.tfvars, demo.tfvars, ithc.tfvars, perftest.tfvars, preview.tfvars, sbox.tfvars).
- A new entry has been added to each file, specifying a route to \"dynatrace-nonprod-vnet\" with an address prefix of \"10.10.80.0/24\", next_hop_type \"VirtualAppliance\", and next_hop_in_ip_address \"10.11.72.36\".