### PR TITLE
DTSPO-18137-update-rt

### DIFF
--- a/environments/network/ptl.tfvars
+++ b/environments/network/ptl.tfvars
@@ -226,7 +226,31 @@ additional_routes = [
     address_prefix         = "10.225.251.0/24"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
-  }
+  },
+  {
+    name                   = "idam-demo"
+    address_prefix         = "10.97.128.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "idam-ithc"
+    address_prefix         = "10.120.64.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "idam-perftest"
+    address_prefix         = "10.120.0.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "idam-preview"
+    address_prefix         = "10.97.64.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
 ]
 
 additional_routes_coreinfra = [


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18137


### Change description ###
updated ptl tfvars with idam jumpbox vnet address space

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- The `ptl.tfvars` file in the `environments/network` directory has been modified to include additional routes for `idam-demo`, `idam-ithc`, `idam-perftest`, and `idam-preview` with their respective address prefixes, next hop types, and IP addresses.