### PR TITLE
Preview: enable MS node updates

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -118,7 +118,7 @@ module "kubernetes" {
 
   enable_automatic_channel_upgrade_patch = var.enable_automatic_channel_upgrade_patch
 
-  enable_node_os_channel_upgrade_nodeimage = contains(["sbox"], var.env) ? true : false
+  enable_node_os_channel_upgrade_nodeimage = contains(["sbox", "preview"], var.env) ? true : false
 
   node_os_maintenance_window_config = var.node_os_maintenance_window_config
 

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -24,3 +24,9 @@ linux_node_pool = {
 
 availability_zones = ["1", "2", "3"]
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18085


### Change description ###

- enable MS node updates for preview


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### components/aks/aks.tf
- Changed the logic for `enable_node_os_channel_upgrade_nodeimage` to include the \"preview\" environment in addition to \"sbox\".

### environments/aks/preview.tfvars
- Added a new configuration for `node_os_maintenance_window_config` with a daily frequency and a start time of 16:00, and marked it as non-production.