### PR TITLE
ITHC: enable node os image upgrades

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -118,7 +118,7 @@ module "kubernetes" {
 
   enable_automatic_channel_upgrade_patch = var.enable_automatic_channel_upgrade_patch
 
-  enable_node_os_channel_upgrade_nodeimage = contains(["sbox"], var.env) ? true : false
+  enable_node_os_channel_upgrade_nodeimage = contains(["sbox", "ithc"], var.env) ? true : false
 
   node_os_maintenance_window_config = var.node_os_maintenance_window_config
 

--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -21,3 +21,9 @@ linux_node_pool = {
 
 availability_zones = ["1", "2", "3"]
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18085


### Change description ###

- enable node os image upgrades ithc


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### components/aks/aks.tf
- Updated the logic for `enable_node_os_channel_upgrade_nodeimage` to include `\"ithc\"` in the environment if block.

### environments/aks/ithc.tfvars
- Added `node_os_maintenance_window_config` settings for ithc environment with a daily frequency and a start time of 16:00.