### PR TITLE
DTSPO-18085 enable node os image upgrades non-prod clusters

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -118,7 +118,7 @@ module "kubernetes" {
 
   enable_automatic_channel_upgrade_patch = var.enable_automatic_channel_upgrade_patch
 
-  enable_node_os_channel_upgrade_nodeimage = contains(["sbox", "ithc"], var.env) ? true : false
+  enable_node_os_channel_upgrade_nodeimage = contains(["sbox", "ithc", "aat", "demo", "perftest", "preview", "ptlsbox"], var.env) ? true : false
 
   node_os_maintenance_window_config = var.node_os_maintenance_window_config
 

--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -21,3 +21,9 @@ linux_node_pool = {
 
 availability_zones = ["1", "2", "3"]
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}

--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -31,3 +31,9 @@ spot_node_pool = {
 
 availability_zones = ["1", "2", "3"]
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}

--- a/environments/aks/perftest.tfvars
+++ b/environments/aks/perftest.tfvars
@@ -24,3 +24,9 @@ linux_node_pool = {
 
 availability_zones = ["1", "2", "3"]
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -24,3 +24,9 @@ linux_node_pool = {
 
 availability_zones = ["1", "2", "3"]
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}

--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -22,3 +22,9 @@ linux_node_pool = {
 
 availability_zones = []
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18085


### Change description ###

- enable node os image upgrades for aat, demo, perftest, preview, ptlsbox


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified components/aks/aks.tf
  - Updated the condition for the 'enable_node_os_channel_upgrade_nodeimage' variable to include additional environment values.

- Modified environments/aks/aat.tfvars, environments/aks/demo.tfvars, environments/aks/perftest.tfvars, environments/aks/preview.tfvars, environments/aks/ptlsbox.tfvars
  - Added the 'node_os_maintenance_window_config' block with frequency \"Daily\", start time \"16:00\", and is_prod set to false in each of the specified tfvars files.