### PR TITLE
DTSPO-18086: Prod - enable node os updates

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -118,7 +118,7 @@ module "kubernetes" {
 
   enable_automatic_channel_upgrade_patch = var.enable_automatic_channel_upgrade_patch
 
-  enable_node_os_channel_upgrade_nodeimage = contains(["sbox", "ithc", "aat", "demo", "perftest", "preview", "ptlsbox"], var.env) ? true : false
+  enable_node_os_channel_upgrade_nodeimage = true
 
   node_os_maintenance_window_config = var.node_os_maintenance_window_config
 

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -25,3 +25,9 @@ monitor_diagnostic_setting_metrics = true
 kube_audit_admin_logs_enabled      = true
 
 availability_zones = ["1", "2", "3"]
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "23:00"
+  is_prod     = true
+}

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -23,3 +23,9 @@ linux_node_pool = {
 
 availability_zones = []
 autoShutdown       = true
+
+node_os_maintenance_window_config = {
+  frequency   = "Daily"
+  start_time  = "16:00"
+  is_prod     = false
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18086


### Change description ###

- enable node os updates on prod
- trialed in sandbox & ithc successfully previous


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `components/aks/aks.tf`:
  - Updated the `enable_node_os_channel_upgrade_nodeimage` to always be true, removing the condition.
 
- `environments/aks/prod.tfvars`:
  - Added a new configuration for `node_os_maintenance_window_config` with frequency set to \"Daily\" and start time at \"23:00\".

- `environments/aks/ptl.tfvars`:
  - Added a new configuration for `node_os_maintenance_window_config` with frequency set to \"Daily\" and start time at \"16:00\", and designated as non-production.