### PR TITLE
Adding a New Azure Linux Node Pool for Sandbox Only

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -73,45 +73,60 @@ module "kubernetes" {
 
   enable_user_system_nodepool_split = var.enable_user_system_nodepool_split == true ? true : false
 
-  additional_node_pools = contains([], var.env) ? tuple([]) : [
-    {
-      name                = "linux"
-      vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")
-      min_count           = lookup(var.linux_node_pool, "min_nodes", 2)
-      max_count           = lookup(var.linux_node_pool, "max_nodes", 4)
-      max_pods            = lookup(var.linux_node_pool, "max_pods", 30)
-      os_type             = "Linux"
-      node_taints         = []
-      enable_auto_scaling = true
-      mode                = "User"
-    },
-    {
-      name                = "cronjob"
-      vm_size             = "Standard_D4ds_v5"
-      min_count           = 0
-      max_count           = 10
-      max_pods            = 30
-      os_type             = "Linux"
-      node_taints         = ["dedicated=jobs:NoSchedule"]
-      enable_auto_scaling = true
-      mode                = "User"
-    },
-    {
-      name                = "spotinstance"
-      vm_size             = lookup(var.spot_node_pool, "vm_size", "Standard_D4ds_v5")
-      min_count           = lookup(var.spot_node_pool, "min_nodes", 0)
-      max_count           = lookup(var.spot_node_pool, "max_nodes", 5)
-      max_pods            = lookup(var.spot_node_pool, "max_pods", 30)
-      os_type             = "Linux"
-      node_taints         = ["kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
-      enable_auto_scaling = true
-      mode                = "User"
-      priority            = "Spot"
-      eviction_policy     = "Delete"
-      spot_max_price      = "-1"
-
-    }
-  ]
+  additional_node_pools = contains([], var.env) ? tuple([]) : concat(
+    [
+      {
+        name                = "linux"
+        vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")
+        min_count           = lookup(var.linux_node_pool, "min_nodes", 2)
+        max_count           = lookup(var.linux_node_pool, "max_nodes", 4)
+        max_pods            = lookup(var.linux_node_pool, "max_pods", 30)
+        os_type             = "Linux"
+        node_taints         = []
+        enable_auto_scaling = true
+        mode                = "User"
+      },
+      {
+        name                = "cronjob"
+        vm_size             = "Standard_D4ds_v5"
+        min_count           = 0
+        max_count           = 10
+        max_pods            = 30
+        os_type             = "Linux"
+        node_taints         = ["dedicated=jobs:NoSchedule"]
+        enable_auto_scaling = true
+        mode                = "User"
+      },
+      {
+        name                = "spotinstance"
+        vm_size             = lookup(var.spot_node_pool, "vm_size", "Standard_D4ds_v5")
+        min_count           = lookup(var.spot_node_pool, "min_nodes", 0)
+        max_count           = lookup(var.spot_node_pool, "max_nodes", 5)
+        max_pods            = lookup(var.spot_node_pool, "max_pods", 30)
+        os_type             = "Linux"
+        node_taints         = ["kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
+        enable_auto_scaling = true
+        mode                = "User"
+        priority            = "Spot"
+        eviction_policy     = "Delete"
+        spot_max_price      = "-1"
+      }
+    ],
+    var.env == "sbox" ? [
+      {
+        name                = "LinuxAzureImage"
+        vm_size             = "Standard_DS3_v2"
+        min_count           = 1
+        max_count           = 1
+        max_pods            = 30
+        os_type             = "Linux"
+        os_sku              = "AzureLinux"
+        node_taints         = []
+        enable_auto_scaling = true
+        mode                = "User"
+      }
+    ] : []
+  )
 
   project_acr_enabled = var.project_acr_enabled
   availability_zones  = var.availability_zones

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -114,7 +114,7 @@ module "kubernetes" {
     ],
     var.env == "sbox" ? [
       {
-        name                = "LinuxAzureImage"
+        name                = "azurelinux"
         vm_size             = "Standard_DS3_v2"
         min_count           = 1
         max_count           = 1


### PR DESCRIPTION
### Jira link (https://tools.hmcts.net/jira/browse/DTSPO-18231)



### Adding a New Azure Linux Node Pool for Sandbox Only ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- In `components/aks/aks.tf`, the additional_node_pools configuration has been updated to include a new environment-specific setting for `azurelinux` when the environment is \"sbox\". This includes the name, vm_size, min_count, max_count, max_pods, os_type, os_sku, node_taints, enable_auto_scaling, and mode. This change allows for a specific node configuration to be used in the \"sbox\" environment. 