### PR TITLE
DTSPO-18669 Upgrade CFT NonProd AKS Clusters to Kubernetes 1.30 - Upgrade demo 00 to 1.30

### DIFF
--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version = "1.29"
+    kubernetes_cluster_version = "1.30"
   },
   "01" = {
     kubernetes_cluster_version = "1.29"

--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -1,10 +1,10 @@
 clusters = {
-  # "00" = {
-  #   kubernetes_cluster_version = "1.29"
-  # },
-  "01" = {
-    kubernetes_cluster_version = "1.25"
-  }
+  "00" = {
+    kubernetes_cluster_version = "1.29"
+  },
+  # "01" = {
+  #   kubernetes_cluster_version = "1.25"
+  # }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"
 ptl_cluster                       = true

--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -1,10 +1,10 @@
 clusters = {
-  "00" = {
-    kubernetes_cluster_version = "1.29"
-  },
-  # "01" = {
-  #   kubernetes_cluster_version = "1.25"
-  # }
+  # "00" = {
+  #   kubernetes_cluster_version = "1.29"
+  # },
+  "01" = {
+    kubernetes_cluster_version = "1.25"
+  }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"
 ptl_cluster                       = true


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-18660](https://tools.hmcts.net/jira/browse/DTSPO-18669)

### Change description

Upgrade demo 00 to 1.30

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


md
- Updated environments/aks/demo.tfvars
  - Changed kubernetes_cluster_version from \"1.29\" to \"1.30\" for the \"00\" cluster
```