### PR TITLE
DTSPO-18669 Upgrade CFT NonProd AKS Clusters to Kubernetes 1.30  - Update aat to 1.30

### DIFF
--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version = "1.29"
+    kubernetes_cluster_version = "1.30"
   },
   "01" = {
     kubernetes_cluster_version = "1.30"


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-18669](https://tools.hmcts.net/jira/browse/DTSPO-18669)

### Change description

upgrade AAT 01 to 1.30 version

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- File: aat.tfvars
- Updated kubernetes_cluster_version from \"1.29\" to \"1.30\" in the \"00\" cluster configuration.