### PR TITLE
PTL: Upgrade AKS version to 1.30

### DIFF
--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -1,9 +1,9 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version = "1.29"
+    kubernetes_cluster_version = "1.30"
   },
   #    "01" = {
-  #      kubernetes_cluster_version = "1.25"
+  #      kubernetes_cluster_version = "1.30"
   #    }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18673


### Change description

- Upgrade PTL AKS version to 1.30



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Changed file: `ptl.tfvars`
- Updated `kubernetes_cluster_version` from \"1.29\" to \"1.30\"
- Added extra space and comma after the closing brace for the \"00\" cluster
- Updated `kubernetes_cluster_ssh_key` with a new SSH key