### PR TITLE
spike/DTSPO-19112

### DIFF
--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -19,7 +19,7 @@ system_node_pool = {
 }
 
 linux_node_pool = {
-  vm_size   = "Standard_D4ds_v5",
+  vm_size   = "Standard_D2ds_v5",
   min_nodes = 4,
   max_nodes = 10
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-19112

### Change description

Spoke to Bhuvan Purushothaman and confirmed that the lowest RI of sku available is `D2ds_v5`

Updated linux sku size from `Standard_D4ds_v5` -> `Standard_D2ds_v5`

testing higher utilization on smaller vm sku's. Current **average** utilisation the following on `D4ds_5` 

- 8% cpu
- 31.6% Ram
- 22.1% Disk

with `D2ds_5` plan to half all resources used so that a higher utlisation can occur with less resources, est cost saving `D4ds_v5` £127.46/pm -> `D2ds_v5` £63.66/pm 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **environments/aks/sbox.tfvars**
  - Updated the `vm_size` from \"Standard_D4ds_v5\" to \"Standard_D2ds_v5\" for the `linux_node_pool`.