### PR TITLE
Revert "spike/DTSPO-19112"

### DIFF
--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -19,7 +19,7 @@ system_node_pool = {
 }
 
 linux_node_pool = {
-  vm_size   = "Standard_D2ds_v5",
+  vm_size   = "Standard_D4ds_v5",
   min_nodes = 4,
   max_nodes = 10
 }


### PR DESCRIPTION
Reverts hmcts/aks-cft-deploy#673

unblock pipeline error - https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=672112&view=logs&j=16ddf0d5-1e10-5fec-9c2d-4314e7f70b81&t=bb8408c3-ac01-5dd5-e3b0-5cafd1c7bafb

## 🤖AEP PR SUMMARY🤖


- The file `environments/aks/sbox.tfvars` has been modified to change the value of the `vm_size` property within the `linux_node_pool` object from \"Standard_D2ds_v5\" to \"Standard_D4ds_v5\". The `min_nodes` value has been updated from 4 to 10.