### PR TITLE
Remove preview 01 since switchover

### DIFF
--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -3,9 +3,9 @@ clusters = {
     kubernetes_cluster_version = "1.30"
   },
 
-   "01" = {
-     kubernetes_cluster_version = "1.30"
-   }
+  // "01" = {
+  //   kubernetes_cluster_version = "1.30"
+  // }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 enable_user_system_nodepool_split = true


### PR DESCRIPTION
Moved to preview-00, but 01 is still built and running

## 🤖AEP PR SUMMARY🤖


- **environments/aks/preview.tfvars**
  - Commented out a cluster configuration with \"kubernetes_cluster_version\" set to \"1.30\" using `//`.
  - Updated the \"node_os_maintenance_window_config\" by setting \"start_time\" to \"16:00\" and \"is_prod\" to false.