### PR TITLE
Update to allow custom linux node pool settings per cluster

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -79,7 +79,7 @@ module "kubernetes" {
       vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")
       min_count           = lookup(var.linux_node_pool, "min_nodes", 2)
       max_count           = lookup(var.linux_node_pool, "max_nodes", 4)
-      max_pods            = lookup(var.linux_node_pool, "max_pods", 30)
+      max_pods            = lookup(var.linux_node_pool[each.key], "max_pods", 30)
       os_type             = "Linux"
       node_taints         = []
       enable_auto_scaling = true

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -76,9 +76,9 @@ module "kubernetes" {
   additional_node_pools = contains([], var.env) ? tuple([]) : [
     {
       name                = "linux"
-      vm_size             = lookup(var.linux_node_pool, "vm_size", "Standard_DS3_v2")
-      min_count           = lookup(var.linux_node_pool, "min_nodes", 2)
-      max_count           = lookup(var.linux_node_pool, "max_nodes", 4)
+      vm_size             = lookup(var.linux_node_pool[each.key], "vm_size", "Standard_DS3_v2")
+      min_count           = lookup(var.linux_node_pool[each.key], "min_nodes", 2)
+      max_count           = lookup(var.linux_node_pool[each.key], "max_nodes", 4)
       max_pods            = lookup(var.linux_node_pool[each.key], "max_pods", 30)
       os_type             = "Linux"
       node_taints         = []

--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -13,10 +13,18 @@ system_node_pool = {
   min_nodes = 4,
   max_nodes = 10
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 30,
-  max_nodes = 80
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 80,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 80,
+  }
 }
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -16,11 +16,20 @@ system_node_pool = {
 }
 
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 5, #Original value was 20, reducing to 5 due to spot instances being enabled
-  max_nodes = 30,
-  max_pods  = 50
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 5,
+    max_nodes = 30,
+    max_pods  = 50
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 5,
+    max_nodes = 30,
+    max_pods  = 50
+  }
 }
+
 
 spot_node_pool = {
   vm_size   = "Standard_D8ds_v5",

--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -13,10 +13,18 @@ system_node_pool = {
   min_nodes = 2,
   max_nodes = 4
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 15,
-  max_nodes = 40
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 15,
+    max_nodes = 40,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 15,
+    max_nodes = 40,
+  }
 }
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/perftest.tfvars
+++ b/environments/aks/perftest.tfvars
@@ -16,10 +16,18 @@ system_node_pool = {
   min_nodes = 4,
   max_nodes = 6
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 30,
-  max_nodes = 100
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 100,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 100,
+  }
 }
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -15,11 +15,20 @@ system_node_pool = {
   min_nodes = 4,
   max_nodes = 6
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 30,
-  max_nodes = 180,
-  max_pods  = 60,
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 180,
+    max_pods  = 60
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 180,
+    max_pods  = 30  
+  }
 }
 
 availability_zones = ["1", "2", "3"]

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -14,10 +14,18 @@ system_node_pool = {
   min_nodes = 4,
   max_nodes = 10
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 30,
-  max_nodes = 100
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 100,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 30,
+    max_nodes = 100,
+  }
 }
 
 monitor_diagnostic_setting         = true

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -15,10 +15,18 @@ system_node_pool = {
   min_nodes = 2,
   max_nodes = 4
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 5,
-  max_nodes = 10
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 5,
+    max_nodes = 10,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 5,
+    max_nodes = 10,
+  }
 }
 
 availability_zones = []

--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -14,10 +14,18 @@ system_node_pool = {
   min_nodes = 2,
   max_nodes = 4
 }
+
 linux_node_pool = {
-  vm_size   = "Standard_D8ds_v5",
-  min_nodes = 3,
-  max_nodes = 10
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 3,
+    max_nodes = 10,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 3,
+    max_nodes = 10,
+  }
 }
 
 availability_zones = []

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -20,12 +20,12 @@ system_node_pool = {
 
 linux_node_pool = {
   "00" = {
-    vm_size   = "Standard_D8ds_v5",
+    vm_size   = "Standard_D4ds_v5",
     min_nodes = 4,
     max_nodes = 10,
   },
   "01" = {
-    vm_size   = "Standard_D8ds_v5",
+    vm_size   = "Standard_D4ds_v5",
     min_nodes = 4,
     max_nodes = 10,
   }

--- a/environments/aks/sbox.tfvars
+++ b/environments/aks/sbox.tfvars
@@ -19,9 +19,16 @@ system_node_pool = {
 }
 
 linux_node_pool = {
-  vm_size   = "Standard_D4ds_v5",
-  min_nodes = 4,
-  max_nodes = 10
+  "00" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 4,
+    max_nodes = 10,
+  },
+  "01" = {
+    vm_size   = "Standard_D8ds_v5",
+    min_nodes = 4,
+    max_nodes = 10,
+  }
 }
 
 spot_node_pool = {


### PR DESCRIPTION
preview subnet is exhausted 

We have around 140 nodes, each with defined max of 60 pods per node, which about fills our subnet so no more autoscaling activity can happen when needed. However, due to these nodes being around 80-100% cpu requested, they only fill with < 30 pods each time. So we're only using around half of the IP address space we're reserving.   (we are looking into this elsewhere)

.ie in 01 right now, we have 6300 ips available, but only around 380 pods currently. There is 30 linux nodes, which means a potential to request 30*60 (1800)

This is around about the number missing from the /19 subnet range that would leave us with 6300 available IPs, suggesting they're being reserved based on node count
Backed up by docs: https://learn.microsoft.com/en-us/azure/aks/azure-cni-overview -- Azure reserves these IPs for a node up front


Dropping this down to 30 pods per node in 01 to switch back over and hopefully allow some more ip address use when autoscaling is needed. Not expecting tf changes elsewhere

This change demands the same across all envs to work, but only preview is actually changing





## 🤖AEP PR SUMMARY🤖


- components/aks/aks.tf
    - Updated the module \"kubernetes\" by changing the way node pool configurations are accessed using the `each` interpolation syntax.

- environments/aks/aat.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.

- environments/aks/demo.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.
    - Added a new \"spot_node_pool\" attribute.

- environments/aks/ithc.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.

- environments/aks/perftest.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.

- environments/aks/preview.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.

- environments/aks/prod.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.
    - Updated the \"monitor_diagnostic_setting\" attribute to \"true\".

- environments/aks/ptl.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.

- environments/aks/ptlsbox.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.

- environments/aks/sbox.tfvars
    - Added additional configurations for the \"linux_node_pool\" attribute under system_node_pool.
    - Added a new \"spot_node_pool\" attribute.