### PR TITLE
Remove preview 00 after switch

### DIFF
--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -1,7 +1,7 @@
 clusters = {
-  "00" = {
-    kubernetes_cluster_version = "1.30"
-  },
+  //"00" = {
+  //  kubernetes_cluster_version = "1.30"
+  //},
 
    "01" = {
      kubernetes_cluster_version = "1.30"
@@ -21,7 +21,7 @@ linux_node_pool = {
     vm_size   = "Standard_D8ds_v5",
     min_nodes = 30,
     max_nodes = 180,
-    max_pods  = 60
+    max_pods  = 30
   },
   "01" = {
     vm_size   = "Standard_D8ds_v5",


### PR DESCRIPTION
Switchover to 01 is now complete
Also reduces max pods per node to 30 same as 01

## 🤖AEP PR SUMMARY🤖


- Changed `preview.tfvars`:
  - Commented out a cluster with version \"1.30\"
  - Updated max_pods value for linux_node_pool
  - Added a new field with node_os_maintenance_window_config