### PR TITLE
add infra-appgws subnet to demo

### DIFF
--- a/environments/network/demo.tfvars
+++ b/environments/network/demo.tfvars
@@ -17,6 +17,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.50.100.0/22"
   },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.50.98.0/25"
+  }
 ]
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"


### PR DESCRIPTION
### Change description
add infra-appgws subnet to demo
- Required for PubSub Service AppGW that EM team will be deploying

Creating an infra appgw subnet that can be shared for any additional appgws

## 🤖AEP PR SUMMARY🤖


### environments/network/demo.tfvars
- Added a new subnet configuration for \"infra-appgws\" with the address prefix \"10.50.98.0/25\".