### PR TITLE
DTSPO-22143 Fixing Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,7 +134,6 @@ stages:
               keyvaultSecret: "azure-devops-sp-token"
               serviceConnection: azurerm-sandbox
               projectName: ${{ variables.project }}
-              cluster: ${{ parameters.cluster }}
               environment: sbox
   - ${{ each component in parameters.environment_components }}:
       - stage: "CheckingClusters_${{ component.env }}"


### PR DESCRIPTION
### Jira link
[DTSPO-22143](https://tools.hmcts.net/jira/browse/DTSPO-22143)


### Change description

Cluster parameter was removed from [terraform pre-check](https://github.com/hmcts/cnp-azuredevops-libraries/commit/9abdd097d06e0ab3ec4dca60146bab5c6b623217)


## 🤖AEP PR SUMMARY🤖



- Removed the 'cluster' parameter from the pipeline configuration in azure-pipelines.yml
