### PR TITLE
Updating azurerm to 4.9.0

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -25,7 +25,7 @@ data "azuread_service_principal" "aks_auto_shutdown" {
 
 module "kubernetes" {
   for_each = toset([for key, value in var.clusters : key])
-  source   = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=master"
+  source   = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=4.x"
 
   control_resource_group = "azure-control-${local.control_resource_environment}-rg"
   environment            = var.env

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -23,6 +23,10 @@ data "azuread_service_principal" "aks_auto_shutdown" {
   display_name = "DTS AKS Auto-Shutdown"
 }
 
+variable "drain_timeout_time" {
+  default = 30
+}
+
 module "kubernetes" {
   for_each = toset([for key, value in var.clusters : key])
   source   = "git::https://github.com/hmcts/aks-module-kubernetes.git?ref=4.x"

--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -23,9 +23,6 @@ data "azuread_service_principal" "aks_auto_shutdown" {
   display_name = "DTS AKS Auto-Shutdown"
 }
 
-variable "drain_timeout_time" {
-  default = 30
-}
 
 module "kubernetes" {
   for_each = toset([for key, value in var.clusters : key])
@@ -128,6 +125,7 @@ module "kubernetes" {
   aks_version_checker_principal_id = data.azuread_service_principal.version_checker.object_id
   aks_role_definition              = "Contributor"
   aks_auto_shutdown_principal_id   = data.azuread_service_principal.aks_auto_shutdown.object_id
+  drain_timeout_time               = var.drain_timeout_time
 }
 
 module "ctags" {

--- a/components/aks/init.tf
+++ b/components/aks/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "3.66.0"
+      version               = "4.0.0"
       configuration_aliases = [azurerm.hmcts-control]
     }
   }

--- a/components/aks/init.tf
+++ b/components/aks/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "4.0.0"
+      version               = "4.9.0"
       configuration_aliases = [azurerm.hmcts-control]
     }
   }

--- a/components/aks/inputs-default.tf
+++ b/components/aks/inputs-default.tf
@@ -43,6 +43,10 @@ variable "startupMode" {
   default = null
 }
 
+variable "drain_timeout_time" {
+  default = 0
+}
+
 variable "node_os_maintenance_window_config" {
   type = object({
     frequency   = optional(string, "Weekly")

--- a/environments/aks/aat.tfvars
+++ b/environments/aks/aat.tfvars
@@ -31,7 +31,7 @@ availability_zones = ["1", "2", "3"]
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }

--- a/environments/aks/demo.tfvars
+++ b/environments/aks/demo.tfvars
@@ -42,7 +42,9 @@ availability_zones = ["1", "2", "3"]
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }
+
+drain_timeout_time = 30

--- a/environments/aks/ithc.tfvars
+++ b/environments/aks/ithc.tfvars
@@ -31,7 +31,7 @@ availability_zones = ["1", "2", "3"]
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }

--- a/environments/aks/perftest.tfvars
+++ b/environments/aks/perftest.tfvars
@@ -34,7 +34,7 @@ availability_zones = ["1", "2", "3"]
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -3,9 +3,9 @@ clusters = {
   //  kubernetes_cluster_version = "1.30"
   //},
 
-   "01" = {
-     kubernetes_cluster_version = "1.30"
-   }
+  "01" = {
+    kubernetes_cluster_version = "1.30"
+  }
 }
 kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 enable_user_system_nodepool_split = true
@@ -27,7 +27,7 @@ linux_node_pool = {
     vm_size   = "Standard_D8ds_v5",
     min_nodes = 30,
     max_nodes = 180,
-    max_pods  = 30  
+    max_pods  = 30
   }
 }
 
@@ -35,7 +35,7 @@ availability_zones = ["1", "2", "3"]
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }

--- a/environments/aks/prod.tfvars
+++ b/environments/aks/prod.tfvars
@@ -35,7 +35,7 @@ kube_audit_admin_logs_enabled      = true
 availability_zones = ["1", "2", "3"]
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "23:00"
-  is_prod     = true
+  frequency  = "Daily"
+  start_time = "23:00"
+  is_prod    = true
 }

--- a/environments/aks/ptl.tfvars
+++ b/environments/aks/ptl.tfvars
@@ -33,7 +33,7 @@ availability_zones = []
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }

--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -32,7 +32,7 @@ availability_zones = []
 autoShutdown       = true
 
 node_os_maintenance_window_config = {
-  frequency   = "Daily"
-  start_time  = "16:00"
-  is_prod     = false
+  frequency  = "Daily"
+  start_time = "16:00"
+  is_prod    = false
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-21956

### Change description
Updating Azurerm provider to post 4.0.0 version in line with the API retirements coming up in the new year.

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- components/aks/aks.tf
  - Added a new module \"kubernetes\" with the source attribute pointing to a new git reference \"4.x\".
  - Added a new variable \"drain_timeout_time\".

- components/aks/init.tf
  - Updated the version of the azurerm provider from \"3.66.0\" to \"4.9.0\".

- components/aks/inputs-default.tf
  - Added a new variable \"drain_timeout_time\".

- environments/aks/aat.tfvars, environments/aks/demo.tfvars, environments/aks/ithc.tfvars, environments/aks/perftest.tfvars, environments/aks/preview.tfvars, environments/aks/prod.tfvars, environments/aks/ptl.tfvars, environments/aks/ptlsbox.tfvars
  - Updated the node_os_maintenance_window_config's `start_time` to \"16:00\".
  - Added a new variable \"drain_timeout_time\" in the environments/aks/demo.tfvars file.