### PR TITLE
Upgrade aks-mis component azurerm version

### DIFF
--- a/components/aks-mis/init.tf
+++ b/components/aks-mis/init.tf
@@ -104,7 +104,7 @@ provider "azurerm" {
   alias                      = "preview"
   skip_provider_registration = "true"
   features {}
-  subscription_id = "8b6ea922-0862-443e-af15-6056e1c9b9a4"
+  subscription_id = var.env == "preview" ? "8b6ea922-0862-443e-af15-6056e1c9b9a4" : "04d27a32-7a07-48b3-95b8-3c8691e1a263"
 }
 
 provider "azurerm" {

--- a/components/aks-mis/init.tf
+++ b/components/aks-mis/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "3.35.0"
+      version               = "4.9.0"
       configuration_aliases = [azurerm.hmcts-control]
     }
   }

--- a/components/aks-mis/init.tf
+++ b/components/aks-mis/init.tf
@@ -104,7 +104,7 @@ provider "azurerm" {
   alias                      = "preview"
   skip_provider_registration = "true"
   features {}
-  subscription_id = var.env == "preview" ? "8b6ea922-0862-443e-af15-6056e1c9b9a4" : "04d27a32-7a07-48b3-95b8-3c8691e1a263"
+  subscription_id = "8b6ea922-0862-443e-af15-6056e1c9b9a4"
 }
 
 provider "azurerm" {


### PR DESCRIPTION
See https://github.com/hmcts/aks-cft-deploy/pull/685 for context

This is no longer an issue in SDS, because there is no aks-mis component there, but we have one in CFT and an azurerm version bump was missed here, so we need to upgrade this too



## 🤖AEP PR SUMMARY🤖


- File: components/aks-mis/init.tf
- Updated the azurerm provider version from 3.35.0 to 4.9.0.