### PR TITLE
Update to use same agent pool for AKS in sds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,6 +271,7 @@ stages:
 
       - stage: Aks_${{ component.env }}
         displayName: "${{ upper(component.env) }}: AKS clusters"
+        pool: hmcts-cftptl-agent-pool
         dependsOn:
           - Managed_Identity_${{ component.env }}
         condition: |


### PR DESCRIPTION
We are still seeing aks api preview deprecation message in cft clusters even after upgrading azureRM everywhere that i can see using the DTS Boostrap SP **and** talking to AKS
This is not happening in SDS though, and all terraform versions etc checks out the same across cft/sds, but only cft is still broken


The error includes the build ID 766 which is our cft-deploy pipeline, which narrows things down
Trying this as it's the only main difference i can see between cft-deploy and sds-deploy

https://github.com/hmcts/aks-sds-deploy/blob/1c6d83563282b0962ee4ce18372679ab647defb6/azure-pipelines.yml#L232C15-L232C38

## 🤖AEP PR SUMMARY🤖


### azure-pipelines.yml
- Added a new pool \"hmcts-cftptl-agent-pool\" for the AKS clusters stage.