### PR TITLE
Update tf version to match SDS

### DIFF
--- a/components/aks-mis/init.tf
+++ b/components/aks-mis/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.10"
+  required_version = ">= 1.2.8"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/aks/init.tf
+++ b/components/aks/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.8"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"


### PR DESCRIPTION
Have now tried several things:
update azurerm to latest
update agent pool to match sds


The error mesage is also mentioning terraform version `/1.10.0` -- SDS-deploy is using 1.2.8, so maybe that's why it is fixed there

## 🤖AEP PR SUMMARY🤖


- **components/aks-mis/init.tf**
  - Updated Terraform required version from \">= 1.0.10\" to \">= 1.2.8\".

- **components/aks/init.tf**
  - Updated Terraform required version from \">= 1.1.7\" to \">= 1.2.8\".