### PR TITLE
DTSPO-22903 Adding infra-appgws subnet to environments

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -16,6 +16,10 @@ additional_subnets = [
   {
     name           = "private-endpoints"
     address_prefix = "10.10.164.0/22"
+  },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.10.169.0/25"
   }
 ]
 

--- a/environments/network/ithc.tfvars
+++ b/environments/network/ithc.tfvars
@@ -17,6 +17,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.11.228.0/22"
   },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.11.226.0/25"
+  }
 ]
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -16,6 +16,10 @@ additional_subnets = [
   {
     name           = "private-endpoints"
     address_prefix = "10.48.100.0/22"
+  },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.48.98.0/25"
   }
 ]
 

--- a/environments/network/preview.tfvars
+++ b/environments/network/preview.tfvars
@@ -17,6 +17,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.101.196.0/22"
   },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.101.194.0/25"
+  }
 ]
 
 private_dns_subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"

--- a/environments/network/prod.tfvars
+++ b/environments/network/prod.tfvars
@@ -16,6 +16,10 @@ additional_subnets = [
   {
     name           = "private-endpoints"
     address_prefix = "10.90.100.0/22"
+  },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.90.98.0/25"
   }
 ]
 

--- a/environments/network/sbox.tfvars
+++ b/environments/network/sbox.tfvars
@@ -17,6 +17,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.2.15.0/24"
   },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.2.16.0/25"
+  }
 ]
 
 private_dns_subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"


### PR DESCRIPTION
### Jira link

[DTSPO-22903](https://tools.hmcts.net/jira/browse/DTSPO-22903)

### Change description

Adding new subnet to environments that has already been added to demo env. Checked address space for free ip range to use on each environment.


## 🤖AEP PR SUMMARY🤖


- Added a new subnet \"infra-appgws\" with the address prefix \"10.10.169.0/25\" to the file `aat.tfvars`.
- Added a new subnet \"infra-appgws\" with the address prefix \"10.11.226.0/25\" to the file `ithc.tfvars`.
- Added a new subnet \"infra-appgws\" with the address prefix \"10.48.98.0/25\" to the file `perftest.tfvars`.
- Added a new subnet \"infra-appgws\" with the address prefix \"10.101.194.0/25\" to the file `preview.tfvars`.
- Added a new subnet \"infra-appgws\" with the address prefix \"10.90.98.0/25\" to the file `prod.tfvars`.
- Added a new subnet \"infra-appgws\" with the address prefix \"10.2.16.0/25\" to the file `sbox.tfvars`.