### PR TITLE
DTSPO-22903 Adjusting sbox address space to allow for new subnet

### DIFF
--- a/environments/network/sbox.tfvars
+++ b/environments/network/sbox.tfvars
@@ -1,6 +1,6 @@
 enable_debug = "true"
 
-network_address_space                  = "10.2.0.0/19"
+network_address_space                  = "10.2.8.0/21"
 aks_00_subnet_cidr_blocks              = "10.2.8.0/23"
 aks_01_subnet_cidr_blocks              = "10.2.10.0/23"
 iaas_subnet_cidr_blocks                = "10.2.12.0/25"

--- a/environments/network/sbox.tfvars
+++ b/environments/network/sbox.tfvars
@@ -1,6 +1,6 @@
 enable_debug = "true"
 
-network_address_space                  = "10.2.8.0/21"
+network_address_space                  = "10.2.0.0/19"
 aks_00_subnet_cidr_blocks              = "10.2.8.0/23"
 aks_01_subnet_cidr_blocks              = "10.2.10.0/23"
 iaas_subnet_cidr_blocks                = "10.2.12.0/24"
@@ -17,6 +17,10 @@ additional_subnets = [
     name           = "private-endpoints"
     address_prefix = "10.2.15.0/24"
   },
+  {
+    name           = "infra-appgws"
+    address_prefix = "10.2.16.0/25"
+  }
 ]
 
 private_dns_subscription = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"

--- a/environments/network/sbox.tfvars
+++ b/environments/network/sbox.tfvars
@@ -3,7 +3,7 @@ enable_debug = "true"
 network_address_space                  = "10.2.0.0/19"
 aks_00_subnet_cidr_blocks              = "10.2.8.0/23"
 aks_01_subnet_cidr_blocks              = "10.2.10.0/23"
-iaas_subnet_cidr_blocks                = "10.2.12.0/24"
+iaas_subnet_cidr_blocks                = "10.2.12.0/25"
 application_gateway_subnet_cidr_blocks = "10.2.13.0/25"
 postgresql_subnet_cidr_blocks          = "10.2.14.128/25"
 postgresql_subnet_expanded_cidr_blocks = "10.2.13.128/25"
@@ -19,7 +19,7 @@ additional_subnets = [
   },
   {
     name           = "infra-appgws"
-    address_prefix = "10.2.16.0/25"
+    address_prefix = "10.2.12.128/25"
   }
 ]
 


### PR DESCRIPTION
### Jira link

[DTSPO-22903](https://tools.hmcts.net/jira/browse/DTSPO-22903)

### Change description

Current address space doesn't have enough room to allow for a new subnet, splitting a subnet to allow room for a new subnet.




## 🤖AEP PR SUMMARY🤖


- Updated sbox.tfvars in environments/network directory
- Changed iaas_subnet_cidr_blocks from \"10.2.12.0/24\" to \"10.2.12.0/25\"
- Added a new subnet \"infra-appgws\" with address prefix \"10.2.12.128/25\"