### PR TITLE
DTSPO-24310: Giving perftest, aat, tihc and prod access to genesis-rg

### DIFF
--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -178,3 +178,11 @@ module "ctags" {
   builtFrom    = var.builtFrom
   expiresAfter = var.expiresAfter
 }
+
+# Gives perftest, ithc, aat and prod access to genesis resource group for WI
+ resource "azurerm_role_assignment" "genesis_rg_contributor" {
+   count                = var.env == "perftest" || var.env == "ithc" || var.env == "aat" || var.env == "prod" ? 1 : 0
+   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id
+   role_definition_name = "Contributor"
+   scope                = data.azurerm_resource_group.genesis_rg.id
+ }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Giving perftest, aat, tihc and prod access to genesis-rg for workload identity

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
