### PR TITLE
Readding prod to azure-pipeline steps for bootstrapping rollout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,12 +98,12 @@ parameters:
         backendAzureRmResourceGroupName: "azure-control-ptl-rg"
         aksKeyVault: "dtscftptl"
         terraformSubscriptionID: "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-      #- env: "prod"
-      #  dependsOn: "aat"
-      #  serviceConnection: "DCD-CFTAPPS-PROD"
-      #  backendAzureRmResourceGroupName: "azure-control-prod-rg"
-      #  aksKeyVault: "dcdcftappsprodkv"
-      #  terraformSubscriptionID: "8cbc6f36-7c56-4963-9d36-739db5d00b27"
+      - env: "prod"
+        dependsOn: "aat"
+        serviceConnection: "DCD-CFTAPPS-PROD"
+        backendAzureRmResourceGroupName: "azure-control-prod-rg"
+        aksKeyVault: "dcdcftappsprodkv"
+        terraformSubscriptionID: "8cbc6f36-7c56-4963-9d36-739db5d00b27"
 
 variables:
   - name: project


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Continuation of the rollout of the changes to the bootstrapping which was added in https://github.com/hmcts/aks-cft-deploy/pull/699.
- Uncommenting prod in azure-pipelines to allowing the new bootstrapping to be applied, which has been edited to use workload identity for flux system.
- PTL and prod were commented out so bootstrapping could be applied to the non-prod environments in https://github.com/hmcts/aks-cft-deploy/pull/699. It has being staged through PTL and is now being applied to prod.

### Testing done

- Similar bootstrapping has already been applied to all environments in sds. For example, PR adding it to prod https://github.com/hmcts/aks-sds-deploy/pull/678.
- Bootstrapping has been applied successfully to cft PTL in this PR: https://github.com/hmcts/aks-cft-deploy/pull/700. Pipeline run applying to PTL: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=795004&view=results
- It has also been applied successfully to the non-prod environments in [this run](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=794918&view=results).

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### azure-pipelines.yml
- Updated the environment to \"prod\" and the dependencies to \"aat\"
- Updated the service connection to \"DCD-CFTAPPS-PROD\"
- Updated the backendAzureRmResourceGroupName to \"azure-control-prod-rg\"
- Updated the aksKeyVault to \"dcdcftappsprodkv\"
- Updated the terraformSubscriptionID to \"8cbc6f36-7c56-4963-9d36-739db5d00b27\"