### PR TITLE
DTSPO-25598 Remove spot instances across CFT

### DIFF
--- a/components/aks/aks.tf
+++ b/components/aks/aks.tf
@@ -96,20 +96,6 @@ module "kubernetes" {
       node_taints         = ["dedicated=jobs:NoSchedule"]
       enable_auto_scaling = true
       mode                = "User"
-    },
-    {
-      name                = "spotinstance"
-      vm_size             = lookup(var.spot_node_pool, "vm_size", "Standard_D4ds_v5")
-      min_count           = lookup(var.spot_node_pool, "min_nodes", 0)
-      max_count           = lookup(var.spot_node_pool, "max_nodes", 5)
-      max_pods            = lookup(var.spot_node_pool, "max_pods", 30)
-      os_type             = "Linux"
-      node_taints         = ["kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
-      enable_auto_scaling = true
-      mode                = "User"
-      priority            = "Spot"
-      eviction_policy     = "Delete"
-      spot_max_price      = "-1"
     }
   ]
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25598

### Change description

- Removes all configurations related to spot instances from the aks-cft-deploy repository for the CFT and SDS environments.
- This change aligns with the decision to stop using spot instances in lower environments to improve stability and consistency.


### Checklist


- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
