### PR TITLE
Route back to PTL from perftest

### DIFF
--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -128,6 +128,12 @@ additional_routes_coreinfra = [
     address_prefix         = "10.146.0.0/21"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "cftptl"
+    address_prefix         = "10.10.72.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 


### PR DESCRIPTION
Jenkins agents are unable to run tests on perftest elastic search VMs due to asymmetric routing

This adds a route for the traffic from perftest elastic back to the palos to complete end to end comms

Tested that fix worked manually in https://build.hmcts.net/job/HMCTS_a_to_c_Nightly/job/ccd-cache-warm-performance/job/master/ -backfilling to code

## 🤖AEP PR SUMMARY🤖


### environments/network/perftest.tfvars
- Added a new route for \"cftptl\" with address prefix \"10.10.72.0/21\" and next hop IP address \"10.11.72.36\".