### PR TITLE
Upgrading AKS version for ptlsbox

### DIFF
--- a/environments/aks/ptlsbox.tfvars
+++ b/environments/aks/ptlsbox.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   "00" = {
-    kubernetes_cluster_version        = "1.30"
+    kubernetes_cluster_version        = "1.32"
     kubernetes_cluster_ssh_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWNmn9m1WkjbXlAWPBeboOjBP9SLc8E6Fsqytdr7pZ3xZ9IwJnzUjYADNuYejCJ0v8KaTF+5THOS0JUIcfmUncE5Kj08o4e/zLxFyNNNfoSePldTMgbbBMd5jTjKB8rBrPif2Oj4e0PjcgEXBVaUvwgoVrh/nkhhzfoydV/DmZ/vpKmJiPrH1plWm8pQheM2g3TrhfIsUXityvPbDBhdCShyLX6I4u10VjZJTXw1DVDVdVYxPKEPUyrYu+qLJGR7M48p0T39nq6bAlxmyQoBdDxgDbZDmfjq2Qyk68xldIlsj/WTXASbY70aO3sV47Qlf7cUEw8ghCWyDCf9Ji2Nbx aks-ssh"
     ptl_cluster                       = true
     enable_user_system_nodepool_split = true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25672

### Change description
Upgrading AKS version for PtlSbox to Version 1.32

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### File `environments/aks/ptlsbox.tfvars`
- Updated `kubernetes_cluster_version` from \"1.30\" to \"1.32\"
- Updated `kubernetes_cluster_ssh_key` with a new RSA key
- Updated `ptl_cluster` to `true`
- Updated `enable_user_system_nodepool_split` to `true`