### PR TITLE
Update cft preview to newly upgraded version 1.32

### DIFF
--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -1,6 +1,6 @@
 clusters = {
   # "00" = {
-  #   kubernetes_cluster_version = "1.30"
+  #   kubernetes_cluster_version = "1.32"
   #   kubernetes_cluster_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 
   #   enable_user_system_nodepool_split = true

--- a/environments/aks/preview.tfvars
+++ b/environments/aks/preview.tfvars
@@ -28,7 +28,7 @@ clusters = {
 
   # },
   "01" = {
-    kubernetes_cluster_version = "1.30"
+    kubernetes_cluster_version = "1.32"
     kubernetes_cluster_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+s99FmkHwqdBbbzgw0Q9vqqJb0VkJ+QrmN5elArYOSX5HER+jAooyOEiZNynoL+oYBZT52p6sSVOvvccl06GX1FNfRkC6A8DlAUeIPO56N4/8awfxT1F1ydjMWHgZcZrPZiFUxH/duvlGqtqnO0iQzWKLsXovGFn0xPRAexK0004Ij1igfMZ+PyxQBunawZFo67cSJu3LpHd/fxqGd/qHBQ1iR01NdRjEBIUKh3/0LxIhOB3I0jxadXGQYXwCV1xefhVrHS13dqJH9tNkHB8YbCQ24hiVd2bmxjBPhS767pfByLkzRIFkYX9l5aSIDl3QLOAQruv5F36kMN9OmyXz aks-ssh"
 
     enable_user_system_nodepool_split = true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25674

### Change description
Update cft preview to newly upgraded version 1.32



## 🤖AEP PR SUMMARY🤖


### environments/aks/preview.tfvars
- Updated `kubernetes_cluster_version` from \"1.30\" to \"1.32\"
- Updated `kubernetes_cluster_ssh_key` value
- Changed `enable_user_system_nodepool_split` to true
- Removed `\ No newline at end of file` and performed other minor formatting changes