### PR TITLE
DTSPO_28864 - Add route table to postgres subnet

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -229,5 +229,8 @@ coreinfra_subnets = [
   },
   {
     name = "core-infra-subnet-apimgmt-aat"
+  },
+  {
+    name = "postgresql"
   }
 ]

--- a/environments/network/prod.tfvars
+++ b/environments/network/prod.tfvars
@@ -134,5 +134,8 @@ coreinfra_subnets = [
   },
   {
     name = "core-infra-subnet-apimgmt-prod"
+  },
+  {
+    name = "postgresql"
   }
 ]


### PR DESCRIPTION
### Jira link

See [DTSPO-28864](https://tools.hmcts.net/jira/browse/DTSPO-28864)

### Change description

Add route table to postgres subnet to ensure traffic from postgres can return to AKS
Required for grafana db to be connected to from ingestion cronjob

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


#### environments/network/aat.tfvars
- Added a new subnet named \"postgresql\" to the coreinfra_subnets list for the AAT environment.

#### environments/network/prod.tfvars
- Added a new subnet named \"postgresql\" to the coreinfra_subnets list for the production environment.