### PR TITLE
DTSPO-28864 - Fix pipeline titles

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,8 +103,6 @@ parameters:
         aksKeyVault: "dcdcftappsprodkv"
         terraformSubscriptionID: "8cbc6f36-7c56-4963-9d36-739db5d00b27"
 
-name: AKS-CFT-Deploy - ${{ parameters.finalAction }}
-
 variables:
   - name: project
     value: cft
@@ -126,6 +124,8 @@ variables:
     ${{ else }}:
       value: ${{ parameters.action }}
   - template: vars/input-variables.yaml@cnp-azuredevops-libraries
+
+name: AKS-CFT-Deploy - ${{ parameters.finalAction }}
 
 stages:
   - stage: PreCheck

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,14 +118,14 @@ variables:
     value: cft-platform
   - name: action
     value: ${{ parameters.action }}
+  - template: vars/input-variables.yaml@cnp-azuredevops-libraries
   - name: finalAction
     ${{ if and(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/master'), in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI', 'PullRequest', 'Schedule'))  }}:
       value: 'apply'
     ${{ else }}:
       value: ${{ parameters.action }}
-  - template: vars/input-variables.yaml@cnp-azuredevops-libraries
 
-name: AKS-CFT-Deploy - ${{ parameters.finalAction }}
+name: AKS-CFT-Deploy - $(finalAction)
 
 stages:
   - stage: PreCheck

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,3 @@
-name: AKS-CFT-Deploy - ${{ parameters.action }}
-
 trigger:
   branches:
     include:
@@ -105,6 +103,8 @@ parameters:
         aksKeyVault: "dcdcftappsprodkv"
         terraformSubscriptionID: "8cbc6f36-7c56-4963-9d36-739db5d00b27"
 
+name: AKS-CFT-Deploy - ${{ parameters.finalAction }}
+
 variables:
   - name: project
     value: cft
@@ -120,6 +120,11 @@ variables:
     value: cft-platform
   - name: action
     value: ${{ parameters.action }}
+  - name: finalAction
+    ${{ if and(in(variables['Build.SourceBranch'], 'refs/heads/main', 'refs/heads/master'), in(variables['Build.Reason'], 'BatchedCI', 'IndividualCI', 'PullRequest', 'Schedule'))  }}:
+      value: 'apply'
+    ${{ else }}:
+      value: ${{ parameters.action }}
   - template: vars/input-variables.yaml@cnp-azuredevops-libraries
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ variables:
     ${{ else }}:
       value: ${{ parameters.action }}
 
-name: AKS-CFT-Deploy - $(finalAction)
+name: "AKS-CFT-Deploy - $(finalAction)"
 
 stages:
   - stage: PreCheck


### PR DESCRIPTION
### Jira link

See [DTSPO-28864](https://tools.hmcts.net/jira/browse/DTSPO-28864)

### Change description

Implementing identical fix as https://github.com/hmcts/aks-sds-deploy/pull/661/files
Removes plan from title of pipeline run when the action is an apply

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- **azure-pipelines.yml**
  - Removed the line `name: AKS-CFT-Deploy ${{ parameters.action }}`
  - Added a new variable `finalAction` to determine the action based on branch and build reason.