### PR TITLE
Add Managed Identity role operator on Azure Policy Manager service principal for aks-prod-mi

### DIFF
--- a/components/managed-identity/inputs-default.tf
+++ b/components/managed-identity/inputs-default.tf
@@ -56,3 +56,9 @@ variable "expiresAfter" {
 variable "service_operator_settings_enabled" {
   default = false
 }
+
+variable "azure_policy_manager_object_id" {
+  description = "Object ID of the azure-policy-manager service principal"
+  type        = string
+  default     = ""
+}

--- a/components/managed-identity/managed-identity.tf
+++ b/components/managed-identity/managed-identity.tf
@@ -13,6 +13,13 @@ resource "azurerm_role_assignment" "MI-Operator" {
   scope                = azurerm_user_assigned_identity.sops-mi.id
 }
 
+resource "azurerm_role_assignment" "MI-Operator-azure-policy-manager" {
+  count                = var.env == "prod" ? 1 : 0
+  scope                = azurerm_user_assigned_identity.sops-mi.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = var.azure_policy_manager_object_id
+}
+
 resource "azurerm_role_assignment" "Reader" {
   # DTS Bootstrap Principal_id
   principal_id         = azurerm_user_assigned_identity.sops-mi.principal_id

--- a/environments/network/prod.tfvars
+++ b/environments/network/prod.tfvars
@@ -139,3 +139,5 @@ coreinfra_subnets = [
     name = "postgresql"
   }
 ]
+
+azure_policy_manager_object_id = "386b3bd7-de44-4ab1-b496-69a84d506572"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27303

### Change description
Assign Managed Identity Operator role with `aks-prod-mi` as a scope to the `Azure Policy Manager` Service Principal
This Service Principal is used by GitHub Action that assigns policies so this change should allow it to associate a "deployIfNotExists" policy I am trying to add with the `aks-prod-mi` Managed Identity.
[This github action is currently failing](https://github.com/hmcts/azure-policy/actions/runs/17557305128/job/49864773425) because it lacks this permission:
```
An error occurred while creating policy assignment.
Error: The client '386b3bd7-de44-4ab1-b496-69a84d506572' with object id '386b3bd7-de44-4ab1-b496-69a84d506572' has permission to perform action 'Microsoft.Authorization/policyAssignments/write' on scope '/providers/Microsoft.Management/managementGroups/HMCTS/providers/Microsoft.Authorization/policyAssignments/AKSDisableCommandInvoke'; however, it does not have permission to perform action(s) 'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action' on the linked scope(s) '/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-prod-mi' (respectively) or the linked scope(s) are invalid.
```
This change will follow similar pattern that already exists on sbox, azure-policy-manager SP can associate aks-sbox-mi with policies.

### Testing done
N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### components/managed-identity/inputs-default.tf
- Added a new variable \"azure_policy_manager_object_id\" with a description and a default value.

### components/managed-identity/managed-identity.tf
- Added a new resource \"azurerm_role_assignment\" for \"MI-Operator-azure-policy-manager\" based on the environment.
- Assigned the principal_id with the variable \"azure_policy_manager_object_id\".

### environments/network/prod.tfvars
- Included the \"azure_policy_manager_object_id\" with a specific value.