### PR TITLE
Update aat.tfvars

### DIFF
--- a/environments/network/aat.tfvars
+++ b/environments/network/aat.tfvars
@@ -97,6 +97,18 @@ additional_routes = [
     address_prefix         = "10.25.33.0/27"
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dlrm_data_aria_sbox1"
+    address_prefix         = "10.247.3.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "dlrm_data_aria_sbox2"
+    address_prefix         = "10.247.4.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
   }
 ]
 


### PR DESCRIPTION
ingest00-sbox vnet requires talking to .internal URLs in AAT - DNS resolution done in https://github.com/hmcts/azure-private-dns/pull/941 - this ensures that next hop from aat to the dlrm aria range goes through nonprod hub as done similarly for other teams - their vnet has two address spaces, so added a rule for both