### PR TITLE
Bootstrap: fix ptl/ptlsbox bootstrap kustomize controller FIC creation

### DIFF
--- a/bootstrap/scripts/install-flux.sh
+++ b/bootstrap/scripts/install-flux.sh
@@ -145,11 +145,25 @@ function flux_github_app_secret {
 function install_flux {
 # Generating WI ResourceGroup manifest
 echo "Deploying Flux - Generating WI manifests"
-download_files "https://api.github.com/repos/hmcts/cnp-flux-config/contents/apps/flux-system/workload-identity" \
-"${TMP_DIR}/gotk" \
-"s|\${WI_CLUSTER}|$ENVIRONMENT-$CLUSTER_NAME|g" \
-"s|\${ENVIRONMENT}|$ENVIRONMENT|g" \
-"s|\${ISSUER_URL}|$ISSUER_URL|g"
+
+WI_FOLDER="apps/flux-system/${CLUSTER_ENV}/workload-identity"
+WI_FOLDER_CHECK="${FLUX_CONFIG_URL}/${WI_FOLDER}/kustomization.yaml"
+
+if curl --output /dev/null --silent --head --fail "${WI_FOLDER_CHECK}"; then
+  echo "Using env-specific workload-identity folder for ${CLUSTER_ENV}"
+  download_files "https://api.github.com/repos/hmcts/cnp-flux-config/contents/${WI_FOLDER}" \
+  "${TMP_DIR}/gotk" \
+  "s|\${WI_CLUSTER}|$ENVIRONMENT-$CLUSTER_NAME|g" \
+  "s|\${ENVIRONMENT}|$ENVIRONMENT|g" \
+  "s|\${ISSUER_URL}|$ISSUER_URL|g"
+else
+  echo "Using shared workload-identity folder"
+  download_files "https://api.github.com/repos/hmcts/cnp-flux-config/contents/apps/flux-system/workload-identity" \
+  "${TMP_DIR}/gotk" \
+  "s|\${WI_CLUSTER}|$ENVIRONMENT-$CLUSTER_NAME|g" \
+  "s|\${ENVIRONMENT}|$ENVIRONMENT|g" \
+  "s|\${ISSUER_URL}|$ISSUER_URL|g"
+fi
 
 # Check if aso-controller-settings-patch.yaml exists for this environment
 ASO_PATCH_URL="${FLUX_CONFIG_URL}/apps/flux-system/${CLUSTER_ENV}/base/aso-controller-settings-patch.yaml"


### PR DESCRIPTION
### Change description

- Currently PTL/PTLSBOX envs for CFT have a clash of federated identity credentials for the kustomize controller - this exists since last AKS upgrades where clusters were re-built and re-bootstrapped
- This is due to bootstrap loading Workload Identity manifests from apps/flux-system/workload-identity/, whereas PTL & PTLSBOX have their own workload-identity manifests in their sub-directories due to deviance in naming structure for postBuild substitutions
- Implement sub-dir check for envs so if sub-dir for WI exists then sub-dir is used, if not then the base apps/flux-system/workload-identity/ is used
- Once bootstrap and flux are both aligned in which WI manifests are used this will fix the duplicate federated identity credential we're seeing currently
- 
<img width="983" height="85" alt="Screenshot 2026-03-10 at 07 35 20" src="https://github.com/user-attachments/assets/574beaf6-997b-48a3-84a9-233b74510fd7" />



### Testing done

- This needs testing but requires rebuild of ptlsbox or ptl


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/aks-cft-deploy/818



## 🤖AEP PR SUMMARY🤖



- **bootstrap/scripts/install-flux.sh** 🚀
  - Enhanced `install_flux` function to conditionally use an environment-specific workload-identity folder if it exists (`apps/flux-system/${CLUSTER_ENV}/workload-identity`), otherwise falls back to the shared folder (`apps/flux-system/workload-identity`).
  - Added a curl check to verify the presence of the environment-specific folder before downloading.
  - Updated download logic to dynamically reference the appropriate folder based on the check.
  - Set new variable `WI_FOLDER_CHECK` for existence check and `WI_FOLDER` for the download path.
  - Introduced `ASO_PATCH_URL` variable to point to a patch YAML file within the environment-specific base folder.
