### PR TITLE
DTSPO-30359: crime-idam ithc add RTs

### DIFF
--- a/environments/network/demo.tfvars
+++ b/environments/network/demo.tfvars
@@ -22,8 +22,9 @@ additional_subnets = [
     address_prefix = "10.50.98.0/25"
   },
   {
-    name           = "crime-idam"
-    address_prefix = "10.50.108.0/24"
+    name                  = "crime-idam"
+    address_prefix        = "10.50.108.0/24"
+    associate_route_table = true
     delegations = {
       postgres_flexible = {
         service_name = "Microsoft.DBforPostgreSQL/flexibleServers"

--- a/environments/network/ithc.tfvars
+++ b/environments/network/ithc.tfvars
@@ -22,8 +22,9 @@ additional_subnets = [
     address_prefix = "10.11.226.0/25"
   },
   {
-    name           = "crime-idam"
-    address_prefix = "10.11.233.0/24"
+    name                  = "crime-idam"
+    address_prefix        = "10.11.233.0/24"
+    associate_route_table = true
     delegations = {
       postgres_flexible = {
         service_name = "Microsoft.DBforPostgreSQL/flexibleServers"

--- a/environments/network/perftest.tfvars
+++ b/environments/network/perftest.tfvars
@@ -22,15 +22,16 @@ additional_subnets = [
     address_prefix = "10.48.98.0/25"
   },
   {
-    name           = "crime-idam"
-    address_prefix = "10.48.105.0/24"
+    name                  = "crime-idam"
+    address_prefix        = "10.48.105.0/24"
+    associate_route_table = true
     delegations = {
       postgres_flexible = {
         service_name = "Microsoft.DBforPostgreSQL/flexibleServers"
         actions      = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
       }
     }
-   nsg_rules = [
+    nsg_rules = [
       {
         name                       = "deny-all-inbound"
         priority                   = 4096

--- a/environments/network/preview.tfvars
+++ b/environments/network/preview.tfvars
@@ -22,8 +22,9 @@ additional_subnets = [
     address_prefix = "10.101.194.0/25"
   },
   {
-    name           = "crime-idam"
-    address_prefix = "10.101.204.0/24"
+    name                  = "crime-idam"
+    address_prefix        = "10.101.204.0/24"
+    associate_route_table = true
     delegations = {
       postgres_flexible = {
         service_name = "Microsoft.DBforPostgreSQL/flexibleServers"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-30359

### Change description

- add Route Table to crime-idam subnet using aks-module-network new merged feature

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/aks-cft-deploy/830

## 🤖AEP PR SUMMARY🤖



- **environments/network/demo.tfvars** 🗂️
  - Updated `crime-idam` subnet by adding `associate_route_table = true`.
  - Added a delegation for `postgres_flexible` service to this subnet.

- **environments/network/ithc.tfvars** 🗂️
  - Updated `crime-idam` subnet by adding `associate_route_table = true`.
  - Added a delegation for `postgres_flexible` service to this subnet.

- **environments/network/perftest.tfvars** 🗂️
  - Updated `crime-idam` subnet by adding `associate_route_table = true`.
  - Added a delegation for `postgres_flexible` service including specific actions.
  - Included a new NSG rule (`deny-all-inbound`) with priority 4096.

- **environments/network/preview.tfvars** 🗂️
  - Updated `crime-idam` subnet by adding `associate_route_table = true`.
  - Added a delegation for `postgres_flexible` service to this subnet.