### PR TITLE
add routing configuration for file-transfer-hub-nonprod

### DIFF
--- a/environments/network/ptl.tfvars
+++ b/environments/network/ptl.tfvars
@@ -257,6 +257,12 @@ additional_routes = [
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.11.72.36"
   },
+  {
+    name                   = "file-transfer-hub-nonprod"
+    address_prefix         = "10.11.63.0/24"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  }
 ]
 
 additional_routes_coreinfra = [


### PR DESCRIPTION
### Jira link

See [DTSPO-30875](https://tools.hmcts.net/jira/browse/DTSPO-30875)

### Change description

Add routing configuration for file-transfer-hub-nonprod.

### Testing done

N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] (No) Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/aks-cft-deploy/831

## 🤖AEP PR SUMMARY🤖



### environments/network/ptl.tfvars
- 🛣️ Added a new additional route named `file-transfer-hub-nonprod` with address prefix `10.11.63.0/24` using a Virtual Appliance at IP `10.11.72.36`.