### PR TITLE
chore: Grant Jenkins environment MIs AKS cluster admin access

### DIFF
--- a/components/aks/jenkins-rbac.tf
+++ b/components/aks/jenkins-rbac.tf
@@ -1,0 +1,55 @@
+locals {
+  jenkins_environment_mis = {
+    aat = {
+      name                = "jenkins-aat-mi"
+      resource_group_name = "managed-identities-aat-rg"
+    }
+    demo = {
+      name                = "jenkins-demo-mi"
+      resource_group_name = "managed-identities-demo-rg"
+    }
+    ithc = {
+      name                = "jenkins-ithc-mi"
+      resource_group_name = "managed-identities-ithc-rg"
+    }
+    perftest = {
+      name                = "jenkins-perftest-mi"
+      resource_group_name = "managed-identities-perftest-rg"
+    }
+    preview = {
+      name                = "jenkins-preview-mi"
+      resource_group_name = "managed-identities-preview-rg"
+    }
+    prod = {
+      name                = "jenkins-prod-mi"
+      resource_group_name = "managed-identities-prod-rg"
+    }
+    ptl = {
+      name                = "jenkins-cftptl-intsvc-mi"
+      resource_group_name = "managed-identities-cftptl-intsvc-rg"
+    }
+    ptlsbox = {
+      name                = "jenkins-cftsbox-intsvc-mi"
+      resource_group_name = "managed-identities-cftsbox-intsvc-rg"
+    }
+    sbox = {
+      name                = "jenkins-sbox-mi"
+      resource_group_name = "managed-identities-sandbox-rg"
+    }
+  }
+}
+
+data "azurerm_user_assigned_identity" "jenkins_environment_mi" {
+  provider            = azurerm.acr
+  name                = local.jenkins_environment_mis[var.env].name
+  resource_group_name = local.jenkins_environment_mis[var.env].resource_group_name
+}
+
+resource "azurerm_role_assignment" "jenkins_environment_mi_aks_admin" {
+  for_each             = var.clusters
+  principal_id         = data.azurerm_user_assigned_identity.jenkins_environment_mi.principal_id
+  role_definition_name = "Azure Kubernetes Service Cluster Admin Role"
+  scope                = "${azurerm_resource_group.kubernetes_resource_group[each.key].id}/providers/Microsoft.ContainerService/managedClusters/${var.project}-${var.env}-${each.key}-${var.service_shortname}"
+
+  depends_on = [module.kubernetes]
+}


### PR DESCRIPTION
### Jira link

See DTSPO-30107 (https://tools.hmcts.net/jira/browse/DTSPO-30107)

### Change description

Grant Jenkins environment-specific managed identities AKS cluster admin access, scoped to the AKS cluster resources managed by this component.

This allows environment-specific Jenkins agents, for example, jenkins-preview-mi, to run az aks get-credentials -a against the target environment AKS cluster without requiring broad subscription-level permissions.

### Testing done

### Security Vulnerability Assessment

CVE Suppression: Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [] README and other documentation has been updated / added (if needed)
- [] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/aks-cft-deploy/834

## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process