### PR TITLE
DTSPO-30107: grant Jenkins MI VNet access

### DIFF
--- a/components/aks/jenkins-rbac.tf
+++ b/components/aks/jenkins-rbac.tf
@@ -45,6 +45,11 @@ data "azurerm_user_assigned_identity" "jenkins_environment_mi" {
   resource_group_name = local.jenkins_environment_mis[var.env].resource_group_name
 }
 
+data "azurerm_virtual_network" "jenkins_environment_mi_network" {
+  name                = local.network_name
+  resource_group_name = local.network_resource_group_name
+}
+
 resource "azurerm_role_assignment" "jenkins_environment_mi_aks_admin" {
   for_each             = var.clusters
   principal_id         = data.azurerm_user_assigned_identity.jenkins_environment_mi.principal_id
@@ -52,4 +57,10 @@ resource "azurerm_role_assignment" "jenkins_environment_mi_aks_admin" {
   scope                = "${azurerm_resource_group.kubernetes_resource_group[each.key].id}/providers/Microsoft.ContainerService/managedClusters/${var.project}-${var.env}-${each.key}-${var.service_shortname}"
 
   depends_on = [module.kubernetes]
+}
+
+resource "azurerm_role_assignment" "jenkins_environment_mi_network_contributor" {
+  principal_id         = data.azurerm_user_assigned_identity.jenkins_environment_mi.principal_id
+  role_definition_name = "Network Contributor"
+  scope                = data.azurerm_virtual_network.jenkins_environment_mi_network.id
 }


### PR DESCRIPTION
Grant the environment Jenkins managed identity Network Contributor on the environment VNet so Jenkins-agent Terraform can read and manage network-backed resources.

https://tools.hmcts.net/jira/browse/DTSPO-30108

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/aks-cft-deploy/842

## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process